### PR TITLE
Fix splitting causes infinite jump

### DIFF
--- a/Scripts/States/Characters/CharacterAirState.cs
+++ b/Scripts/States/Characters/CharacterAirState.cs
@@ -15,15 +15,19 @@ public sealed partial class CharacterAirState : CharacterState
 
     public override State Process(double delta)
     {
-        if (CharacterContext.Controller.IsSplitting)
+        var controller = CharacterContext.Controller;
+        var cloneable = CharacterContext.Cloneable;
+
+        if (controller.IsSplitting && controller.IsMoving)
         {
-            if (CharacterContext.Cloneable?.Mirror is null)
+            if (cloneable?.Mirror is null)
             {
                 return SplitState;
             }
-            else if (!CharacterContext.Cloneable.IsClone)
+            // if mirror exists, merge unless there is no cloneable component
+            else if (!cloneable?.IsClone ?? false)
             {
-                CharacterContext.Cloneable.Merge();
+                cloneable.Merge();
             }
         }
 

--- a/Scripts/States/Characters/CharacterIdleState.cs
+++ b/Scripts/States/Characters/CharacterIdleState.cs
@@ -20,6 +20,15 @@ public partial class CharacterIdleState : CharacterState
             return MoveState;
         }
 
+        // We need this check because a state like SplitState can just enter
+        // to idle without checking if we are on the floor. Without this check,
+        // the player can perform an extra instant jump after splitting in
+        // mid-air.
+        if (!CharacterContext.IsOnFloor())
+        {
+            return AirState;
+        }
+
         return null;
     }
 


### PR DESCRIPTION
Fixes #21 

Note this does not fix the potential issue of a player repeatedly splitting upwards to gain altitude, but this fixes the bug where a player gets an extra jump after splitting.

This was caused by not checking if the player was in the air when transitioning from split to idle state, which causes the player to perform an extra jump exactly on the frame right after splitting.