### PR TITLE
Fix rocket causing self-damage

### DIFF
--- a/Entities/ProjectileExplosionSpawner.cs
+++ b/Entities/ProjectileExplosionSpawner.cs
@@ -18,6 +18,7 @@ public partial class ProjectileExplosionSpawner : Node, IProjectileHitHandlerCom
 
         // TODO: use a World class to add the explosion instance
         explosionInstance.GlobalPosition = projectile.GlobalPosition;
+        explosionInstance.OwnerCharacter = projectile.OwnerCharacter;
 
         // defer since the projectile has monitoring set
         projectile.GetParent().CallDeferred("add_child", explosionInstance);


### PR DESCRIPTION
Rocket should not damage the player but still apply knockback. This PR fixes it since the explosion scene's owner character was not set to the player.