### PR TITLE
Add signals to States and StateMachines

### DIFF
--- a/States/State.cs
+++ b/States/State.cs
@@ -3,8 +3,15 @@ using Godot;
 
 namespace CrossedDimensions.States;
 
+[GlobalClass]
 public partial class State : Node
 {
+    [Signal]
+    public delegate void EnteredEventHandler(State previousState);
+
+    [Signal]
+    public delegate void ExitedEventHandler(State nextState);
+
     public virtual Node Context { get; set; }
 
     /// <summary>
@@ -13,6 +20,7 @@ public partial class State : Node
     /// </summary>
     public virtual State Enter(State previousState)
     {
+        EmitSignal(SignalName.Entered, previousState);
         return EnterChildren(previousState);
     }
 
@@ -46,6 +54,7 @@ public partial class State : Node
     /// </summary>
     public virtual void Exit(State nextState)
     {
+        EmitSignal(SignalName.Exited, nextState);
         ExitChildren(nextState);
     }
 

--- a/States/StateMachine.cs
+++ b/States/StateMachine.cs
@@ -4,12 +4,16 @@ namespace CrossedDimensions.States;
 
 /// <summary>
 /// A state machine that manages states for a given context node. The node
-/// should delegate its process, physics process, and input events to the
-/// state machine, which will in turn delegate them to the current state.
+/// should delegate its state-specific process, physics process, and input
+/// events to the state machine, which will in turn delegate them to the
+/// current state.
 /// </summary>
 [GlobalClass]
 public partial class StateMachine : Node
 {
+    [Signal]
+    public delegate void StateChangedEventHandler(State previousState, State newState);
+
     /// <summary>
     /// The node that this state machine is managing.
     /// </summary>
@@ -51,12 +55,17 @@ public partial class StateMachine : Node
             return;
         }
 
+        var previousState = CurrentState;
+
         CurrentState?.Exit(newState);
 
-        // recursively enter the new state
-        var previousState = CurrentState;
+        // set and emit change
         CurrentState = newState;
         CurrentState.Context = Context;
+
+        EmitSignal(SignalName.StateChanged, previousState, CurrentState);
+
+        // recursively enter the new state
         ChangeState(CurrentState.Enter(previousState));
     }
 


### PR DESCRIPTION
Closes #23.

This pull request introduces event signaling to the state management system, making it easier for other parts of the codebase to respond to state transitions. The main changes are the addition of custom signals for entering and exiting states, as well as for when the state machine changes states, and ensuring these signals are emitted at the appropriate times.

- Added `Entered` and `Exited` signals to the `State` class, and emit these signals when a state is entered or exited. [[1]](diffhunk://#diff-130841e4a71878b5848cabd6a5b917173d9fba9f74b7083426f7105f58c74a84R8-R13) [[2]](diffhunk://#diff-130841e4a71878b5848cabd6a5b917173d9fba9f74b7083426f7105f58c74a84R22) [[3]](diffhunk://#diff-130841e4a71878b5848cabd6a5b917173d9fba9f74b7083426f7105f58c74a84R56)
- Added a `StateChanged` signal to the `StateMachine` class, and emit this signal whenever the current state changes. [[1]](diffhunk://#diff-975d3f1bc213bfd0095f73b26885dda5f686594a2fa0486bd021009ff08561e9L7-R16) [[2]](diffhunk://#diff-975d3f1bc213bfd0095f73b26885dda5f686594a2fa0486bd021009ff08561e9R58-R68)