### PR TITLE
chore: Remove debug print statements

### DIFF
--- a/BoundingBoxes/Hitbox.cs
+++ b/BoundingBoxes/Hitbox.cs
@@ -49,7 +49,6 @@ public partial class Hitbox : BoundingBox
 
     public void OnHitboxAreaEntered(Area2D area)
     {
-        GD.Print("hit");
         if (area is Hurtbox hurtbox)
         {
             if (!CanHitSelf && hurtbox.OwnerCharacter == OwnerCharacter)

--- a/Environment/Puzzles/SwitchButton.cs
+++ b/Environment/Puzzles/SwitchButton.cs
@@ -18,15 +18,13 @@ public partial class SwitchButton : Area2D
         this.BodyExited += OnArea2DBodyExited;
         if (Door == null)
         {
-            GD.PrintErr("SwitchButton could not find parent SwitchDoor!");
+            throw new System.Exception("SwitchButton requires a SwitchDoor to function.");
         }
-        GD.Print("SwitchButton ready!");
     }
     private void OnArea2DBodyEntered(Node body)
     {
         if (body is CharacterBody2D)
         {
-            GD.Print("Switch area entered by body!");
             SwitchPressed = true;
             Sprite.Texture = PressedTexture;
             Door?.Activate();
@@ -34,7 +32,6 @@ public partial class SwitchButton : Area2D
     }
     private void OnArea2DBodyExited(Node body)
     {
-        GD.Print("Switch area left by body!");
         if (body is CharacterBody2D)
         {
             SwitchPressed = false;

--- a/Environment/Puzzles/SwitchDoor.cs
+++ b/Environment/Puzzles/SwitchDoor.cs
@@ -38,14 +38,12 @@ public partial class SwitchDoor : Node
     }
     private void OpenDoor()
     {
-        GD.Print("Door open!");
         Open = true;
         DoorCollider.CallDeferred("set_disabled", true);
         Sprite.Texture = OpenTexture;
     }
     private void CloseDoor()
     {
-        GD.Print("Door closed!");
         Open = false;
         DoorCollider.CallDeferred("set_disabled", false);
         Sprite.Texture = ClosedTexture;

--- a/States/Characters/CharacterIdleState.cs
+++ b/States/Characters/CharacterIdleState.cs
@@ -69,7 +69,6 @@ public partial class CharacterIdleState : CharacterState
         {
             //reset allow jumping input if on ground
             CharacterContext.AllowJumpInput = true;
-            GD.Print("$On ground (idle), restoring jump input");
         }
 
         return null;

--- a/States/Characters/CharacterMoveState.cs
+++ b/States/Characters/CharacterMoveState.cs
@@ -72,7 +72,6 @@ public partial class CharacterMoveState : CharacterState
         {
             //reset allow jumping input if on ground
             CharacterContext.AllowJumpInput = true;
-            GD.Print("$On ground (moving), restoring jump input");
         }
 
         return null;

--- a/States/Characters/CharacterState.cs
+++ b/States/Characters/CharacterState.cs
@@ -32,7 +32,7 @@ public partial class CharacterState : State
             .GetSetting("physics/2d/default_gravity")
             .AsSingle();
 
-        //apply gravity boost if the player recently released a jump 
+        //apply gravity boost if the player recently released a jump
         if (CharacterContext.JumpGravBoostTime > 0)
         {
             float t_left = CharacterContext.JumpGravBoostTime
@@ -41,7 +41,6 @@ public partial class CharacterState : State
             {
                 CharacterContext.JumpGravBoostTime = 0;
                 CharacterContext.JumpHeldAtTime = 0;
-                GD.Print($"Gravity boost expired");
             }
             else
             {
@@ -74,15 +73,7 @@ public partial class CharacterState : State
         {
             CharacterContext.AllowJumpInput = false;
             CharacterContext.JumpReleasedAtTime = Time.GetTicksMsec();
-            CharacterContext.JumpGravBoostTime = t_left / gravity_k;
-            if (CharacterContext.JumpGravBoostTime > 0)
-            {
-                GD.Print($"Gravity boost time: {CharacterContext.JumpGravBoostTime}");
-            }
-            else
-            {
-                CharacterContext.JumpGravBoostTime = 0;
-            }
+            CharacterContext.JumpGravBoostTime = Mathf.Max(0, t_left / gravity_k);
         }
 
         if (CharacterContext.AllowJumpInput)


### PR DESCRIPTION
This pull request primarily removes debug print statements across several files to clean up the codebase and replaces an error log with an exception in the `SwitchButton` logic. Closes #97 

**Debug/Logging Cleanup:**
* Removed various `GD.Print` debug statements from `Hitbox.cs`, `SwitchButton.cs`, `SwitchDoor.cs`, and character state files to reduce console noise and improve code clarity. [[1]](diffhunk://#diff-6c7b4de7d6aa6191f470ba7819f358c457eec9162401b6a4c3443d58144390a7L52) [[2]](diffhunk://#diff-cabdf3565153bf1bcb6bd5fe45e73f9d1104b68b893fbb1ead051abeb205b311L21-L37) [[3]](diffhunk://#diff-6a33299ef9f4e7061771438f26340a4ebb6154deae05bbeea871f8330a1b6732L41-L48) [[4]](diffhunk://#diff-15367a4be9dea7d69b4bfa352f3f18eb7eea2b93162da1411ec6239acddb4c35L72) [[5]](diffhunk://#diff-01915cbd01970c02fb9d741230b6c3d95f6d1f3cc19ed442193178fd6e1c5a2aL75) [[6]](diffhunk://#diff-47559febdc59643b76ac2e94b72d35f020ddbf3fd54d2171c524c9ba702ab860L44)

**Error Handling Improvements:**
* Changed the error handling in `SwitchButton.cs` to throw an exception if a required `SwitchDoor` is missing, instead of just logging an error message.