### PR TITLE
fix: Make Characters unable to spam split with cooldown

### DIFF
--- a/Characters/CloneableComponent.cs
+++ b/Characters/CloneableComponent.cs
@@ -37,6 +37,12 @@ public sealed partial class CloneableComponent : Node
     public float SplitForce { get; set; } = 768f;
 
     /// <summary>
+    /// The minimum amount of time between split attempts, in seconds.
+    /// </summary>
+    [Export]
+    public double SplitCooldownDuration { get; set; } = 0.5;
+
+    /// <summary>
     /// Splits the character, creating a mirrored clone. The character can
     /// only be split if there is no existing clone.
     /// </summary>

--- a/States/Characters/CharacterAirState.cs
+++ b/States/Characters/CharacterAirState.cs
@@ -20,7 +20,9 @@ public sealed partial class CharacterAirState : CharacterState
 
         if (controller.IsSplitting && controller.IsMoving)
         {
-            if (cloneable?.Mirror is null)
+            var splitState = SplitState as CharacterSplitState;
+            if (cloneable?.Mirror is null &&
+                (splitState is null || splitState.CanSplit))
             {
                 return SplitState;
             }

--- a/States/Characters/CharacterMoveState.cs
+++ b/States/Characters/CharacterMoveState.cs
@@ -40,7 +40,9 @@ public partial class CharacterMoveState : CharacterState
 
         if (CharacterContext.Controller.IsSplitting)
         {
-            if (CharacterContext.Cloneable?.Mirror is null)
+            var splitState = SplitState as CharacterSplitState;
+            if (CharacterContext.Cloneable?.Mirror is null &&
+                (splitState is null || splitState.CanSplit))
             {
                 return SplitState;
             }


### PR DESCRIPTION
Characters have a 0.5s cooldown before being able to split again.