### PR TITLE
fix health bar display value

### DIFF
--- a/Characters/CloneableComponent.cs
+++ b/Characters/CloneableComponent.cs
@@ -120,8 +120,6 @@ public sealed partial class CloneableComponent : Node
             return;
         }
 
-        EmitSignal(SignalName.CharacterMerged, Original);
-
         int maxHealth = Character.Health.MaxHealth + Mirror.Health.MaxHealth;
         int health = Character.Health.CurrentHealth + Mirror.Health.CurrentHealth;
 
@@ -135,9 +133,10 @@ public sealed partial class CloneableComponent : Node
         else
         {
             Character.Health.SetStats(health, maxHealth);
-
             Clone.QueueFree();
             Clone = null;
         }
+
+        EmitSignal(SignalName.CharacterMerged, Original);
     }
 }

--- a/UI/UIPlayerHud/player_health_bar.gd
+++ b/UI/UIPlayerHud/player_health_bar.gd
@@ -9,11 +9,13 @@ var _full_length = 100
 func update_health(value: int) -> void:
 	progress_bar.value = value
 	
-func set_health_bar_half() -> void:
+func set_health_bar_half(max_health: int) -> void:
 	progress_bar.size.x = _half_length
+	progress_bar.max_value = max_health
 
-func set_health_bar_full() -> void:
+func set_health_bar_full(max_health: int) -> void:
 	progress_bar.size.x = _full_length
+	progress_bar.max_value = max_health
 	
 func hide_health_bar() -> void:
 	visible = false;

--- a/UI/UIPlayerHud/player_hud.gd
+++ b/UI/UIPlayerHud/player_hud.gd
@@ -32,8 +32,6 @@ func _on_main_health_changed(_old_health: int):
 #Updates the CloneHealthBar Scene to display to current health of the clone
 func _on_clone_health_changed(_old_health: int):
 	var new_health: int = clone.Health.CurrentHealth
-	print("Clone health changed:", new_health)
-	#parentClass.childclass.functionCall()
 	health_bars.clone_health_bar.update_health(new_health)
 #Summary
 #Is called when the CharacterSplitPost signal is emmited
@@ -44,11 +42,16 @@ func _on_character_split(_orig_character, clone_character: Character):
 	clone = clone_character
 	clone_character.get_node("%PlayerHud").queue_free()
 	clone_character.Health.connect(&"HealthChanged", _on_clone_health_changed)
-	health_bars.main_health_bar.set_health_bar_half()
+	health_bars.main_health_bar.set_health_bar_half(character.Health.MaxHealth)
+	health_bars.clone_health_bar.set_health_bar_half(clone.Health.MaxHealth)
+	_on_clone_health_changed(1) #set clone health to current health
+	_on_main_health_changed(1) #set player health to current health
 	health_bars.clone_health_bar.show_health_bar()
+	
+
 
 func _on_character_merge(_orig_character: Character):
 	#hide the clonehealth bar
-	health_bars.main_health_bar.set_health_bar_full()
+	health_bars.main_health_bar.set_health_bar_full(character.Health.MaxHealth)
 	health_bars.clone_health_bar.hide_health_bar()
-	
+	_on_main_health_changed(1) #ensures the most upto date health value is shown. 


### PR DESCRIPTION
Fixed the health bars so that they now display value of health correctly matches the player and clone's actual health. Also fixed the signal for merging so that it is emited after the merge and after the health gets recalulated.