### PR TITLE
Add .cs.uid to .gitignore

### DIFF
--- a/CrossedDimensions.Tests/.gitignore
+++ b/CrossedDimensions.Tests/.gitignore
@@ -1,2 +1,5 @@
 bin/
 obj/
+
+# ignore uids for test files
+*.cs.uid


### PR DESCRIPTION
This pull request makes a minor update to the `.gitignore` file in the `CrossedDimensions.Tests` directory. The change ensures that `.cs.uid` files generated by Godot are ignored by Git, preventing them from being tracked in the repository.