### PR TITLE
Replace enemies with cave variants

### DIFF
--- a/Entities/Enemies/Bug/Bug.tscn
+++ b/Entities/Enemies/Bug/Bug.tscn
@@ -11,7 +11,7 @@
 [ext_resource type="Script" uid="uid://ca34tm7a0qjwx" path="res://States/Characters/CharacterMoveState.cs" id="9_3kqtw"]
 [ext_resource type="Script" uid="uid://dseku1fko6r7x" path="res://States/Characters/CharacterAirState.cs" id="10_rw2jg"]
 [ext_resource type="Script" uid="uid://bks6bqyscxh45" path="res://Components/HealthComponent.cs" id="11_l6qw7"]
-[ext_resource type="Script" path="res://Entities/Enemies/queue_free_death_handler.gd" id="12_fg8op"]
+[ext_resource type="Script" uid="uid://b4n02rdxirgry" path="res://Entities/Enemies/queue_free_death_handler.gd" id="12_fg8op"]
 [ext_resource type="Script" uid="uid://u7a6ad2ljwu6" path="res://BoundingBoxes/Hurtbox.cs" id="13_wcgpv"]
 [ext_resource type="Script" uid="uid://vpwodcd2x2h8" path="res://BoundingBoxes/Hitbox.cs" id="14_fjvoo"]
 [ext_resource type="Script" uid="uid://jg644ea4xgbf" path="res://Components/DamageComponent.cs" id="15_jir08"]
@@ -39,10 +39,10 @@ animations = [{
 }]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ftt6i"]
-size = Vector2(56, 43)
+size = Vector2(56, 29)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_8rjni"]
-size = Vector2(60, 29)
+size = Vector2(60, 19)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_8k7vh"]
 size = Vector2(72, 29)
@@ -98,7 +98,7 @@ script = ExtResource("10_rw2jg")
 IdleState = NodePath("../Idle")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(0, 8.5)
+position = Vector2(0, 15.5)
 shape = SubResource("RectangleShape2D_ftt6i")
 
 [node name="HealthComponent" type="Node" parent="."]
@@ -117,7 +117,7 @@ HealthComponent = NodePath("../HealthComponent")
 OwnerCharacter = NodePath("..")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hurtbox"]
-position = Vector2(0, 1.5)
+position = Vector2(0, 6.5)
 shape = SubResource("RectangleShape2D_8rjni")
 
 [node name="Hitbox" type="Area2D" parent="." node_paths=PackedStringArray("DamageComponent")]

--- a/Entities/Enemies/PlantTurret/PlantTurret.tscn
+++ b/Entities/Enemies/PlantTurret/PlantTurret.tscn
@@ -14,7 +14,7 @@
 [ext_resource type="Script" uid="uid://55mecbw5gtg8" path="res://Entities/Enemies/Behaviors/AimAtTarget.gd" id="12_2sutj"]
 [ext_resource type="Script" uid="uid://wfj73cx4255u" path="res://States/Characters/CharacterFrozenState.cs" id="13_q0blh"]
 [ext_resource type="Script" uid="uid://bks6bqyscxh45" path="res://Components/HealthComponent.cs" id="14_2x66r"]
-[ext_resource type="Script" path="res://Entities/Enemies/queue_free_death_handler.gd" id="15_87hel"]
+[ext_resource type="Script" uid="uid://b4n02rdxirgry" path="res://Entities/Enemies/queue_free_death_handler.gd" id="15_87hel"]
 [ext_resource type="Script" uid="uid://u7a6ad2ljwu6" path="res://BoundingBoxes/Hurtbox.cs" id="16_xlwqp"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_5fxq0"]

--- a/Scenes/CaveLevel.tscn
+++ b/Scenes/CaveLevel.tscn
@@ -12,15 +12,15 @@
 [ext_resource type="Script" uid="uid://vpwodcd2x2h8" path="res://BoundingBoxes/Hitbox.cs" id="5_fmbnd"]
 [ext_resource type="PackedScene" uid="uid://droah6sh8svm7" path="res://Entities/Enemies/EnemySpawner.tscn" id="5_xb17f"]
 [ext_resource type="Texture2D" uid="uid://chglv1xa77uj3" path="res://Assets/Textures/Tilesets/CaveTileset/CaveStalagmiteBack.tres" id="5_yr7uy"]
-[ext_resource type="PackedScene" uid="uid://d3fk3t1473ls6" path="res://Entities/Enemies/Scuttler/Scuttler.tscn" id="6_4chb8"]
 [ext_resource type="Script" uid="uid://jg644ea4xgbf" path="res://Components/DamageComponent.cs" id="6_qmfys"]
-[ext_resource type="PackedScene" uid="uid://b7s650bc5xheg" path="res://Entities/Enemies/Turret/TurretEnemy.tscn" id="7_4chb8"]
 [ext_resource type="Script" uid="uid://lbx2ts7wodyq" path="res://Audio/Area2DMusicTrigger.cs" id="7_c4me2"]
 [ext_resource type="AudioStream" uid="uid://n2xqnognjoq4" path="res://Assets/Music/cave-theme.tres" id="8_bcse6"]
 [ext_resource type="Texture2D" uid="uid://ckve58d5igrxy" path="res://Assets/Textures/Tilesets/CaveTileset/stalactites.png" id="10_he0xv"]
 [ext_resource type="PackedScene" uid="uid://2fq0fpjsf4bn" path="res://Entities/Enemies/Bat/Bat.tscn" id="12_bcse6"]
 [ext_resource type="Texture2D" uid="uid://bopnsg6xs5hi1" path="res://Assets/Textures/Tilesets/CaveTileset/PinkCrystal.tres" id="19_0n7cc"]
+[ext_resource type="PackedScene" uid="uid://vw0oskdl7ucp" path="res://Entities/Enemies/Bug/Bug.tscn" id="19_apm6s"]
 [ext_resource type="Texture2D" uid="uid://cv3sniqryuxxd" path="res://Assets/Textures/Tilesets/CaveTileset/PurpleCrystal.tres" id="20_b4uka"]
+[ext_resource type="PackedScene" uid="uid://drqfxmaq70fsu" path="res://Entities/Enemies/PlantTurret/PlantTurret.tscn" id="20_he0xv"]
 
 [sub_resource type="Environment" id="Environment_1wd8j"]
 background_mode = 3
@@ -999,13 +999,13 @@ shape = SubResource("RectangleShape2D_s00wl")
 [node name="Scuttler" parent="Enemies" instance=ExtResource("5_xb17f")]
 position = Vector2(816, -656)
 SpawnRange = 512
-EnemyScene = ExtResource("6_4chb8")
+EnemyScene = ExtResource("19_apm6s")
 
-[node name="DebugTurret" parent="Enemies" instance=ExtResource("7_4chb8")]
-position = Vector2(1920, -622)
+[node name="PlantTurret" parent="Enemies" instance=ExtResource("20_he0xv")]
+position = Vector2(1920, -624)
 
-[node name="DebugTurret2" parent="Enemies" instance=ExtResource("7_4chb8")]
-position = Vector2(2336, -622)
+[node name="PlantTurret2" parent="Enemies" instance=ExtResource("20_he0xv")]
+position = Vector2(2336, -624)
 
 [node name="Bat spawner" parent="Enemies" instance=ExtResource("5_xb17f")]
 position = Vector2(744, -352)
@@ -1051,7 +1051,7 @@ wait_time = 30.0
 
 [node name="Scuttler spawner" parent="Enemies" instance=ExtResource("5_xb17f")]
 position = Vector2(2128, -352)
-EnemyScene = ExtResource("6_4chb8")
+EnemyScene = ExtResource("19_apm6s")
 
 [node name="Timer" parent="Enemies/Scuttler spawner" index="0"]
 wait_time = 30.0

--- a/States/Weapons/Behaviors/FireProjectileBehavior.cs
+++ b/States/Weapons/Behaviors/FireProjectileBehavior.cs
@@ -14,7 +14,7 @@ public partial class FireProjectileBehavior : WeaponState
     {
         var projectile = ProjectileScene.Instantiate<Entities.Projectile>();
         projectile.OwnerCharacter = Weapon.OwnerCharacter;
-        projectile.GlobalPosition = projectile.OwnerCharacter.GlobalPosition
+        projectile.GlobalPosition = Weapon.GlobalPosition
             + Offset;
         projectile.Rotation = Weapon.Target.Angle();
 


### PR DESCRIPTION
- Replaces the enemies in the cave level with their cave variants
- Changes the hitbox of the cave variants to match their sprite
- Changes the projectile spawner to spawn projectiles at the weapon position rather than character position, which allows turrets to shoot from its cannon instead of the root character node's position