### PR TITLE
feature: Add damage feedback animation

### DIFF
--- a/Characters/Character.tscn
+++ b/Characters/Character.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://cjo8oxurlpsup"]
+[gd_scene load_steps=22 format=3 uid="uid://cjo8oxurlpsup"]
 
 [ext_resource type="Script" uid="uid://t5xa8pqv2chw" path="res://Characters/Character.cs" id="1_xloa1"]
 [ext_resource type="Script" uid="uid://dqpkcaajawmmr" path="res://Characters/CloneableComponent.cs" id="2_peemv"]
@@ -18,6 +18,7 @@
 [ext_resource type="PackedScene" uid="uid://diyetqkjfxg45" path="res://Scenes/PauseMenu.tscn" id="15_gxkbl"]
 [ext_resource type="Texture2D" uid="uid://d02ajcqv81keo" path="res://Assets/Textures/Player/shale-arm.png" id="16_5ocvt"]
 [ext_resource type="Script" uid="uid://cn1vv5mqclgbe" path="res://Characters/PlayerAnimator.cs" id="17_pv7kk"]
+[ext_resource type="Script" uid="uid://b5bo4jr5pc7ie" path="res://UI/DamageFeedbackController.cs" id="18_r1xqh"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_xloa1"]
 size = Vector2(16, 24)
@@ -106,6 +107,28 @@ shape = SubResource("RectangleShape2D_fgiha")
 [node name="PlayerHud" parent="CanvasLayer" node_paths=PackedStringArray("character") instance=ExtResource("14_fgvlp")]
 unique_name_in_owner = true
 character = NodePath("../..")
+
+[node name="DamageFeedbackLayer" type="CanvasLayer" parent="."]
+layer = 250
+
+[node name="DamageOverlay" type="ColorRect" parent="DamageFeedbackLayer"]
+visible = false
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0, 0, 0, 1)
+
+[node name="DamageFeedback" type="Node" parent="." node_paths=PackedStringArray("HealthComponent", "Camera", "Overlay", "SpriteAnchor")]
+script = ExtResource("18_r1xqh")
+HealthComponent = NodePath("../HealthComponent")
+Camera = NodePath("../Camera2D")
+Overlay = NodePath("../DamageFeedbackLayer/DamageOverlay")
+SpriteAnchor = NodePath("../SpriteAnchor")
+MinTimeScale = 0.125
+ShakeStrength = 16.0
+DamageToIntensity = 0.4
+MinimumIntensity = 0.5
+SpriteHighlightGain = 2.0
 
 [node name="SpriteAnchor" type="Node2D" parent="."]
 

--- a/UI/DamageFeedbackController.cs
+++ b/UI/DamageFeedbackController.cs
@@ -1,0 +1,191 @@
+using Godot;
+using CrossedDimensions.Components;
+
+namespace CrossedDimensions.UI;
+
+[GlobalClass]
+public partial class DamageFeedbackController : Node
+{
+    [Export]
+    public HealthComponent HealthComponent { get; set; }
+
+    [Export]
+    public Camera2D Camera { get; set; }
+
+    [Export]
+    public ColorRect Overlay { get; set; }
+
+    [Export]
+    public Node2D SpriteAnchor { get; set; }
+
+    [ExportCategory("Feedback")]
+    [Export]
+    public float OverlayMaxAlpha { get; set; } = 0.75f;
+
+    [Export]
+    public float OverlayFadeSpeed { get; set; } = 2.5f;
+
+    [Export]
+    public float MinTimeScale { get; set; } = 0.6f;
+
+    [Export]
+    public float TimeScaleHoldDuration { get; set; } = 0.25f;
+
+    [Export]
+    public float ShakeDuration { get; set; } = 0.25f;
+
+    [Export]
+    public float ShakeStrength { get; set; } = 12.0f;
+
+    [Export]
+    public float DamageToIntensity { get; set; } = 1.5f;
+
+    [Export]
+    public float MinimumIntensity { get; set; } = 0.15f;
+
+    [Export]
+    public float SpriteHighlightGain { get; set; } = 0.6f;
+
+    [Export]
+    public float SpriteHighlightRecovery { get; set; } = 0.3f;
+
+    private float _overlayAlpha;
+    private float _shakeRemaining;
+    private float _shakeStrength;
+    private float _spriteHighlightTimer;
+    private float _timeScaleHoldRemaining;
+    private float _targetTimeScale = 1f;
+    private Vector2 _cameraBasePosition = Vector2.Zero;
+    private Color _overlayBaseColor = new Color(0, 0, 0, 1);
+    private Color _spriteBaseModulate = new Color(1, 1, 1, 1);
+    private readonly RandomNumberGenerator _rng = new();
+
+    public override void _Ready()
+    {
+        _rng.Randomize();
+
+        if (HealthComponent is not null)
+        {
+            HealthComponent.HealthChanged += OnHealthChanged;
+        }
+
+        if (Camera is not null)
+        {
+            _cameraBasePosition = Camera.Position;
+        }
+
+        if (Overlay is not null)
+        {
+            _overlayBaseColor = Overlay.Color;
+            Overlay.Color = _overlayBaseColor with { A = 0f };
+            Overlay.Visible = false;
+        }
+
+        if (SpriteAnchor is not null)
+        {
+            _spriteBaseModulate = SpriteAnchor.Modulate;
+        }
+    }
+
+    public override void _Process(double delta)
+    {
+        float dt = (float)delta;
+
+        if (Overlay is not null && _overlayAlpha > 0f)
+        {
+            _overlayAlpha = Mathf.Max(0f, _overlayAlpha - OverlayFadeSpeed * dt);
+            Overlay.Color = _overlayBaseColor with { A = _overlayAlpha };
+
+            if (_overlayAlpha <= 0.01f)
+            {
+                Overlay.Visible = false;
+            }
+        }
+
+        if (_timeScaleHoldRemaining > 0f)
+        {
+            _timeScaleHoldRemaining = Mathf.Max(0f, _timeScaleHoldRemaining - dt);
+        }
+        else if (Engine.TimeScale < 1f)
+        {
+            Engine.TimeScale = 1f;
+        }
+
+        if (Camera is not null)
+        {
+            if (_shakeRemaining > 0f)
+            {
+                _shakeRemaining = Mathf.Max(0f, _shakeRemaining - dt);
+                float progress = Mathf.Clamp(_shakeRemaining / (ShakeDuration + 0.0001f), 0f, 1f);
+                Vector2 jitter = new Vector2(
+                    _rng.RandfRange(-1f, 1f),
+                    _rng.RandfRange(-1f, 1f)) * _shakeStrength * progress;
+                Camera.Position = _cameraBasePosition + jitter;
+            }
+            else
+            {
+                Camera.Position = _cameraBasePosition;
+            }
+        }
+
+        if (SpriteAnchor is not null)
+        {
+            if (_spriteHighlightTimer > 0f)
+            {
+                _spriteHighlightTimer = Mathf.Max(0f, _spriteHighlightTimer - dt);
+                float highlightProgress = Mathf.Clamp(_spriteHighlightTimer / SpriteHighlightRecovery, 0f, 1f);
+                float boost = 1f + highlightProgress * SpriteHighlightGain;
+                SpriteAnchor.Modulate = _spriteBaseModulate * boost;
+            }
+            else
+            {
+                SpriteAnchor.Modulate = _spriteBaseModulate;
+            }
+        }
+    }
+
+    private void OnHealthChanged(int oldHealth)
+    {
+        if (HealthComponent is null)
+        {
+            return;
+        }
+
+        int newHealth = HealthComponent.CurrentHealth;
+        if (newHealth <= 0)
+        {
+            return;
+        }
+
+        int damage = oldHealth - newHealth;
+        if (damage <= 0)
+        {
+            return;
+        }
+
+        float normalized = Mathf.Clamp(damage / (HealthComponent.MaxHealth * DamageToIntensity), MinimumIntensity, 1f);
+        TriggerFeedback(normalized);
+    }
+
+    private void TriggerFeedback(float intensity)
+    {
+        if (Overlay is not null)
+        {
+            Overlay.Visible = true;
+            _overlayAlpha = OverlayMaxAlpha * intensity;
+            Overlay.Color = _overlayBaseColor with { A = _overlayAlpha };
+        }
+
+        float targetScale = Mathf.Clamp(1f - intensity * (1f - MinTimeScale), MinTimeScale, 1f);
+        Engine.TimeScale = Mathf.Min(Engine.TimeScale, targetScale);
+        _timeScaleHoldRemaining = TimeScaleHoldDuration * intensity;
+
+        _shakeRemaining = ShakeDuration * intensity;
+        _shakeStrength = ShakeStrength * intensity;
+
+        if (SpriteAnchor is not null)
+        {
+            _spriteHighlightTimer = SpriteHighlightRecovery * intensity;
+        }
+    }
+}

--- a/UI/DamageFeedbackController.cs.uid
+++ b/UI/DamageFeedbackController.cs.uid
@@ -1,0 +1,1 @@
+uid://b5bo4jr5pc7ie


### PR DESCRIPTION
Resolves #127.

Adds a damage feedback system for characters, through a `DamageFeedbackController` component and updating the character scene to integrate this feature. It currently provides dark overlays, camera shake, sprite highlighting, and time scaling when a character takes damage. Currently, there are no sprite animations for taking damage.

Integration of damage feedback system:

* Added a new script `DamageFeedbackController.cs` that manages visual feedback (overlay, camera shake, sprite highlight, and time scaling) in response to health changes.
* Registered the new script resource in `DamageFeedbackController.cs.uid`.

Scene updates for feedback components:

* Updated `Character.tscn` to include a `CanvasLayer` named `DamageFeedbackLayer` and a `ColorRect` named `DamageOverlay` for displaying damage feedback overlays.
* Integrated the `DamageFeedbackController` into the `Character.tscn` scene, connecting it to relevant nodes (`HealthComponent`, `Camera`, `Overlay`, `SpriteAnchor`) and exposing configuration parameters for feedback effects. [[1]](diffhunk://#diff-08601e935a478d455eb1c4c2af70398089e8ba07ac53470c43329f4cd1d83300R111-R132) [[2]](diffhunk://#diff-08601e935a478d455eb1c4c2af70398089e8ba07ac53470c43329f4cd1d83300R21)
* Incremented the `load_steps` in `Character.tscn` to account for the new resources.