### PR TITLE
feature: Add clone death handler

### DIFF
--- a/Characters/Character.tscn
+++ b/Characters/Character.tscn
@@ -12,7 +12,7 @@
 [ext_resource type="Script" uid="uid://3gwoekpmt5om" path="res://States/Characters/CharacterSplitState.cs" id="8_omicx"]
 [ext_resource type="Script" uid="uid://bks6bqyscxh45" path="res://Components/HealthComponent.cs" id="11_fgiha"]
 [ext_resource type="Script" uid="uid://u7a6ad2ljwu6" path="res://BoundingBoxes/Hurtbox.cs" id="11_p3cti"]
-[ext_resource type="Script" uid="uid://bmna34a4thb44" path="res://UI/UIDeathScreen/death_handler.gd" id="12_6s7kk"]
+[ext_resource type="Script" uid="uid://2eq4bkx445ky" path="res://Characters/PlayerDeathHandler.cs" id="12_pv7kk"]
 [ext_resource type="PackedScene" uid="uid://c0m8rgcsh18sw" path="res://UI/UIPlayerHud/PlayerHud.tscn" id="14_fgvlp"]
 [ext_resource type="Texture2D" uid="uid://dr1ss6b1in635" path="res://Assets/Textures/Player/shale-neutral.png" id="15_5ocvt"]
 [ext_resource type="PackedScene" uid="uid://diyetqkjfxg45" path="res://Scenes/PauseMenu.tscn" id="15_gxkbl"]
@@ -88,8 +88,9 @@ script = ExtResource("11_fgiha")
 MaxHealth = 100
 CurrentHealth = 100
 
-[node name="DeathHandler" type="Node" parent="HealthComponent"]
-script = ExtResource("12_6s7kk")
+[node name="DeathHandler" type="Node" parent="HealthComponent" node_paths=PackedStringArray("Character")]
+script = ExtResource("12_pv7kk")
+Character = NodePath("../..")
 
 [node name="Hurtbox" type="Area2D" parent="." node_paths=PackedStringArray("HealthComponent", "OwnerCharacter")]
 position = Vector2(0, -5)

--- a/Characters/PlayerDeathHandler.cs
+++ b/Characters/PlayerDeathHandler.cs
@@ -1,0 +1,42 @@
+using Godot;
+
+namespace CrossedDimensions.Characters;
+
+public partial class PlayerDeathHandler : Node
+{
+    [Export]
+    public Character Character { get; set; }
+
+    public override void _Ready()
+    {
+        Character.Health.HealthChanged += OnHealthChanged;
+    }
+
+    private void OnHealthChanged(int oldHealth)
+    {
+        if (Character.Health.IsAlive)
+        {
+            return;
+        }
+
+        if (Character.Cloneable?.IsClone ?? false)
+        {
+            OnCloneCharacterDeath();
+        }
+        else
+        {
+            OnOriginalCharacterDeath();
+        }
+    }
+
+    private void OnOriginalCharacterDeath()
+    {
+        const string ScenePath = "res://Scenes/DeathScreen.tscn";
+        GetTree().CallDeferred("change_scene_to_file", ScenePath);
+    }
+
+    private void OnCloneCharacterDeath()
+    {
+        Character.Cloneable?.Original?.Cloneable?.Merge();
+    }
+}

--- a/Characters/PlayerDeathHandler.cs.uid
+++ b/Characters/PlayerDeathHandler.cs.uid
@@ -1,0 +1,1 @@
+uid://2eq4bkx445ky


### PR DESCRIPTION
Refactors the character death handling logic by replacing the previous GDScript-based handler with a new C# implementation. The new `PlayerDeathHandler` class centralizes death-related behavior, distinguishing between original and clone character deaths. Clone deaths automatically merge the clone, while main character deaths should remain the same.

Death handling refactor:

* Introduced a new C# class `PlayerDeathHandler` to handle character death events, replacing the previous GDScript handler. This class listens for health changes and triggers appropriate actions for original and clone characters.
* Updated `Characters/Character.tscn` to reference the new `PlayerDeathHandler.cs` script instead of the old GDScript handler, and set up the character node path for proper linkage. [[1]](diffhunk://#diff-08601e935a478d455eb1c4c2af70398089e8ba07ac53470c43329f4cd1d83300L15-R15) [[2]](diffhunk://#diff-08601e935a478d455eb1c4c2af70398089e8ba07ac53470c43329f4cd1d83300L91-R93)
* Added the unique identifier file for `PlayerDeathHandler.cs` to support the new script resource.