### PR TITLE
fix: Fix splitting autoequipping first weapon

### DIFF
--- a/Components/InventoryComponent.cs
+++ b/Components/InventoryComponent.cs
@@ -150,7 +150,7 @@ public partial class InventoryComponent : Node2D
             nextIndex += weapons.Count;
         }
 
-        EquipWeapon(weapons[nextIndex]);
+        EquipWeapon(weapons[nextIndex], false);
     }
 
     private void OnWeaponNextRequested()

--- a/CrossedDimensions.Tests/Integration/CharacterInventoryIntegrationTest.cs
+++ b/CrossedDimensions.Tests/Integration/CharacterInventoryIntegrationTest.cs
@@ -205,4 +205,22 @@ public class CharacterInventoryIntegrationTest : IDisposable
         clone.Inventory.EquippedWeapon.Name.ToString().ShouldBe(_rocketLauncher2.Name.ToString());
         clone.Inventory.EquippedWeapon.ShouldNotBeSameAs(_rocketLauncher2);
     }
+
+    [Fact]
+    public void GivenCharacterWithClone_WhenCyclingWeapon_ThenBothCharactersCycleIndependently()
+    {
+        var inventory = _character.Inventory;
+
+        inventory.EquipWeapon(_rocketLauncher1);
+
+        var clone = _character.Cloneable.Split();
+        clone.Inventory._Ready();
+
+        inventory.CycleWeapon(1);
+
+        inventory.EquippedWeapon.Name.ToString()
+            .ShouldBe(_rocketLauncher2.Name.ToString());
+        clone.Inventory.EquippedWeapon.Name.ToString()
+            .ShouldBe(_rocketLauncher1.Name.ToString());
+    }
 }


### PR DESCRIPTION
Clones entering the world previously automatically equipped the first weapon rather than the weapon they were holding before split.

This pull request updates the weapon equipping logic in the `InventoryComponent` to provide more control over recursive equipment synchronization between character clones. The key change is the introduction of a `recursive` boolean parameter to weapon equip methods, allowing callers to specify whether equipping actions should propagate to mirrored clones.

Weapon equipping API changes:

* Added a `recursive` boolean parameter (defaulting to `true`) to `EquipWeapon`, `EquipWeaponByName`, and `EquipWeaponByIndex` methods, enabling callers to control whether weapon equipping should be recursively applied to mirrored clones. [[1]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6L192-R192) [[2]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6L244-R248) [[3]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6L257-R257)
* Updated internal logic in `EquipWeapon` to only synchronize weapon equipment with a clone if `recursive` is `true`.

Usage updates:

* Modified all internal calls to weapon equip methods (including in `_Ready` and `PostCharacterSplit`) to explicitly set `recursive: false`, preventing unwanted recursive synchronization when equipping weapons during initialization or character splitting. [[1]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6L88-R88) [[2]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6L182-R182)