### PR TITLE
Improve death screen and pause menu

### DIFF
--- a/Assets/UITheme.tres
+++ b/Assets/UITheme.tres
@@ -1,8 +1,10 @@
-[gd_resource type="Theme" load_steps=8 format=3 uid="uid://b5cn5pegvkqek"]
+[gd_resource type="Theme" load_steps=9 format=3 uid="uid://b5cn5pegvkqek"]
 
 [ext_resource type="FontFile" uid="uid://6cp1nunudfin" path="res://Assets/Fonts/calamity.ttf" id="1_4pui4"]
 [ext_resource type="StyleBox" uid="uid://b0du55sgo2po5" path="res://Assets/Themes/SaveButtonBorderHover.tres" id="1_8yhhh"]
 [ext_resource type="StyleBox" uid="uid://clffn7382jf26" path="res://Assets/Themes/SaveButtonBorder.tres" id="2_12gbe"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_2nv5f"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_tapkf"]
 
@@ -16,6 +18,7 @@
 default_font = ExtResource("1_4pui4")
 default_font_size = 15
 Button/colors/font_pressed_color = Color(1, 1, 1, 0.49803922)
+Button/styles/disabled = SubResource("StyleBoxEmpty_2nv5f")
 Button/styles/focus = SubResource("StyleBoxEmpty_tapkf")
 Button/styles/hover = SubResource("StyleBoxEmpty_g3wn2")
 Button/styles/hover_pressed = null

--- a/Saves/SaveManager.cs
+++ b/Saves/SaveManager.cs
@@ -113,7 +113,9 @@ public partial class SaveManager : Node
             throw new ArgumentException("Path cannot be empty. Provide a path to the save file.", nameof(path));
         }
 
-        var loaded = ResourceLoader.Load(path);
+        var loaded = ResourceLoader
+            .Load(path, cacheMode: ResourceLoader.CacheMode.ReplaceDeep);
+
         if (loaded == null)
         {
             throw new Exception($"Failed to load SaveFile from '{path}'.");
@@ -159,7 +161,8 @@ public partial class SaveManager : Node
 
         GD.Print($"Loading developer default save from '{DeveloperDefaultPath}'.");
 
-        var defaultResource = ResourceLoader.Load(DeveloperDefaultPath);
+        var defaultResource = ResourceLoader
+            .Load(DeveloperDefaultPath, cacheMode: ResourceLoader.CacheMode.ReplaceDeep);
         if (defaultResource is not SaveFile template)
         {
             throw new Exception($"Developer default save not found at '{DeveloperDefaultPath}'.");
@@ -258,5 +261,27 @@ public partial class SaveManager : Node
         }
 
         return saves;
+    }
+
+    /// <summary>
+    /// Reload the currently active save from persistent storage if it exists.
+    /// If the save file cannot be found or reloaded this method returns the
+    /// current in-memory <see cref="CurrentSave"/> (which may be null).
+    /// </summary>
+    public SaveFile ReloadCurrentSave()
+    {
+        if (CurrentSave is null)
+        {
+            return null;
+        }
+
+        string path = SavePathForName(CurrentSave.SaveName);
+
+        if (!FileAccess.FileExists(path))
+        {
+            return CreateNewSave();
+        }
+
+        return ReadPersistent(path);
     }
 }

--- a/Saves/SceneManager.cs
+++ b/Saves/SceneManager.cs
@@ -23,14 +23,16 @@ public partial class SceneManager : Node
     {
         Instance = this;
     }
+
     public void LoadSceneSync(string scenePath)
     {
         _ = LoadScene(scenePath);
     }
+
     /// <summary>
     /// Load a scene by path, using the cache when available.
     /// </summary>
-    public async Task LoadScene(string scenePath)
+    public async Task LoadScene(string scenePath, bool forceReload = false)
     {
         if (string.IsNullOrEmpty(scenePath))
         {
@@ -38,8 +40,9 @@ public partial class SceneManager : Node
             return;
         }
 
-        if (!_cache.TryGetValue(scenePath, out var packed))
+        if (forceReload || !_cache.TryGetValue(scenePath, out var packed))
         {
+            GD.Print($"SceneManager: loading scene '{scenePath}' from disk.");
             packed = ResourceLoader.Load<PackedScene>(scenePath);
             if (packed == null)
             {
@@ -48,9 +51,13 @@ public partial class SceneManager : Node
             }
             _cache[scenePath] = packed;
         }
+        else
+        {
+            GD.Print($"SceneManager: using cached scene '{scenePath}'.");
+        }
         PreviousScene = GetTree().CurrentScene?.SceneFilePath ?? "";
         GetTree().ChangeSceneToPacked(packed);
-        await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
+        await ToSignal(GetTree(), SceneTree.SignalName.SceneChanged);
     }
 
     public void LoadSceneFromSave(SaveFile save)
@@ -86,11 +93,7 @@ public partial class SceneManager : Node
 
         string currentScene = GetTree().CurrentScene?.SceneFilePath ?? "";
 
-        if (currentScene != scenePath)
-        {
-            await LoadScene(scenePath);
-            await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
-        }
+        await LoadScene(scenePath, forceReload: true);
 
         MovePlayer(position);
     }
@@ -127,7 +130,6 @@ public partial class SceneManager : Node
         if (currentScene != scenePath)
         {
             await LoadScene(scenePath);
-            await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
         }
 
         var marker = GetTree()

--- a/UI/UIDeathScreen/DeathScreen.cs
+++ b/UI/UIDeathScreen/DeathScreen.cs
@@ -1,0 +1,18 @@
+using System;
+using Godot;
+
+namespace CrossedDimensions.UI.UIDeathScreen;
+
+public partial class DeathScreen : Control
+{
+    public override void _Ready()
+    {
+        var priorities = Enum.GetValues(typeof(Audio.MusicPriority))
+            as Audio.MusicPriority[];
+
+        foreach (Audio.MusicPriority priority in priorities)
+        {
+            Audio.MusicManager.Instance.StopTrack(priority);
+        }
+    }
+}

--- a/UI/UIDeathScreen/DeathScreen.cs.uid
+++ b/UI/UIDeathScreen/DeathScreen.cs.uid
@@ -1,0 +1,1 @@
+uid://bprh7dnxh6v06

--- a/UI/UIDeathScreen/DeathScreen.tscn
+++ b/UI/UIDeathScreen/DeathScreen.tscn
@@ -1,29 +1,143 @@
-[gd_scene load_steps=5 format=3 uid="uid://b0ym5tvwl4fq"]
+[gd_scene load_steps=8 format=3 uid="uid://b0ym5tvwl4fq"]
 
 [ext_resource type="Script" uid="uid://bvgmopuweeiph" path="res://UI/UIDeathScreen/retry_level_button.gd" id="1_6ck0u"]
+[ext_resource type="Theme" uid="uid://b5cn5pegvkqek" path="res://Assets/UITheme.tres" id="1_y6j7i"]
+[ext_resource type="Script" uid="uid://bprh7dnxh6v06" path="res://UI/UIDeathScreen/DeathScreen.cs" id="2_ke1f7"]
 [ext_resource type="Script" uid="uid://bim6n4gufhp77" path="res://UI/UIDeathScreen/quit_to_home_button.gd" id="2_y6j7i"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_r42lw"]
-bg_color = Color(0.2592937, 0.2592937, 0.2592937, 1)
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 3
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
+[sub_resource type="Animation" id="Animation_y6j7i"]
+resource_name = "start"
+length = 2.000025
+step = 0.25
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("DeathMenuSelect/DeathMessage:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.5, 1),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("DeathMenuSelect/RetryLevelButton:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 1, 1.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("DeathMenuSelect/QuitToHomeButton:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 1.5, 2),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("DeathMenuSelect/RetryLevelButton:disabled")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("DeathMenuSelect/QuitToHomeButton:disabled")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 1.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4pnsc"]
-bg_color = Color(0.427493, 0.42749307, 0.42749307, 1)
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
+[sub_resource type="Animation" id="Animation_ke1f7"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("DeathMenuSelect/DeathMessage:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("DeathMenuSelect/RetryLevelButton:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("DeathMenuSelect/QuitToHomeButton:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("DeathMenuSelect/RetryLevelButton:disabled")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("DeathMenuSelect/QuitToHomeButton:disabled")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_47n8c"]
+_data = {
+&"RESET": SubResource("Animation_ke1f7"),
+&"start": SubResource("Animation_y6j7i")
+}
 
 [node name="DeathScreen" type="Control"]
 layout_mode = 3
@@ -32,6 +146,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_y6j7i")
+script = ExtResource("2_ke1f7")
 metadata/_edit_lock_ = true
 
 [node name="ColorRect" type="ColorRect" parent="."]
@@ -41,7 +157,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.23392546, 0.23392546, 0.23392543, 1)
+color = Color(0, 0, 0, 1)
 metadata/_edit_lock_ = true
 
 [node name="DeathMenuSelect" type="VBoxContainer" parent="."]
@@ -51,37 +167,36 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -172.5
-offset_top = -82.5
-offset_right = 172.5
-offset_bottom = 82.5
+offset_left = -53.5
+offset_top = -28.0
+offset_right = 53.5
+offset_bottom = 28.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/separation = 20
 
 [node name="DeathMessage" type="Label" parent="DeathMenuSelect"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 48
 text = "YOU ARE DEAD"
 metadata/_edit_lock_ = true
 
 [node name="RetryLevelButton" type="Button" parent="DeathMenuSelect"]
-custom_minimum_size = Vector2(150, 40)
 layout_mode = 2
 size_flags_horizontal = 4
 mouse_default_cursor_shape = 2
-theme_override_font_sizes/font_size = 24
-theme_override_styles/normal = SubResource("StyleBoxFlat_r42lw")
-theme_override_styles/hover = SubResource("StyleBoxFlat_4pnsc")
-text = "RETRY"
+disabled = true
+text = "Retry"
 script = ExtResource("1_6ck0u")
 
 [node name="QuitToHomeButton" type="Button" parent="DeathMenuSelect"]
-custom_minimum_size = Vector2(150, 40)
 layout_mode = 2
 size_flags_horizontal = 4
 mouse_default_cursor_shape = 2
-theme_override_font_sizes/font_size = 24
-theme_override_styles/normal = SubResource("StyleBoxFlat_r42lw")
-theme_override_styles/hover = SubResource("StyleBoxFlat_4pnsc")
-text = "QUIT"
+text = "Quit"
 script = ExtResource("2_y6j7i")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+&"": SubResource("AnimationLibrary_47n8c")
+}
+autoplay = "start"

--- a/UI/UIDeathScreen/retry_level_button.gd
+++ b/UI/UIDeathScreen/retry_level_button.gd
@@ -4,10 +4,6 @@ func _pressed() -> void:
 	var save_manager: SaveManager = get_node("/root/SaveManager")
 	var scene_manager: SceneManager = get_node("/root/SceneManager")
 
-	var save: SaveFile = save_manager.CurrentSave
-
-	if save == null:
-		get_tree().change_scene_to_file("res://Scenes/CaveLevel.tscn")
-		return
+	var save: SaveFile = save_manager.ReloadCurrentSave()
 
 	scene_manager.LoadSceneFromSave(save)

--- a/UI/UIPauseMenu/PauseMenu.tscn
+++ b/UI/UIPauseMenu/PauseMenu.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=12 format=3 uid="uid://diyetqkjfxg45"]
+[gd_scene load_steps=10 format=3 uid="uid://diyetqkjfxg45"]
 
+[ext_resource type="Theme" uid="uid://b5cn5pegvkqek" path="res://Assets/UITheme.tres" id="1_k3t2n"]
 [ext_resource type="Script" uid="uid://muq4jm8hft3t" path="res://UI/UIPauseMenu/pause_menu.gd" id="1_lj4oq"]
 [ext_resource type="Shader" uid="uid://87yyoy3o8021" path="res://Shaders/PauseMenu.gdshader" id="2_qwhev"]
 [ext_resource type="PackedScene" uid="uid://dg2qr26pm4ke3" path="res://UI/UISettings/SettingsSelect.tscn" id="3_5w4ur"]
@@ -8,49 +9,8 @@
 shader = ExtResource("2_qwhev")
 shader_parameter/lod = 0.0
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2eowd"]
-bg_color = Color(0.2592937, 0.2592937, 0.2592937, 1)
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 3
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lj4oq"]
-bg_color = Color(0.427493, 0.42749307, 0.42749307, 1)
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qwhev"]
-bg_color = Color(0.2592937, 0.2592937, 0.2592937, 1)
-border_width_left = 3
-border_width_top = 3
-border_width_right = 3
-border_width_bottom = 3
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5w4ur"]
-bg_color = Color(0.427493, 0.42749307, 0.42749307, 1)
-border_width_left = 1
-border_width_top = 1
-border_width_right = 1
-border_width_bottom = 1
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_k3t2n"]
+bg_color = Color(0, 0, 0, 0.7529412)
 
 [sub_resource type="Animation" id="Animation_siy43"]
 length = 0.001
@@ -121,6 +81,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_k3t2n")
 script = ExtResource("1_lj4oq")
 metadata/_edit_lock_ = true
 
@@ -136,73 +97,60 @@ grow_vertical = 2
 [node name="PanelContainer" type="PanelContainer" parent="."]
 modulate = Color(1, 1, 1, 0)
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -92.5
-offset_top = -99.5
-offset_right = 92.5
-offset_bottom = 99.5
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_k3t2n")
 
-[node name="PauseMenuSelect" type="VBoxContainer" parent="PanelContainer"]
-clip_contents = true
-layout_mode = 2
-size_flags_vertical = 4
-
-[node name="PauseMessage" type="Label" parent="PanelContainer/PauseMenuSelect"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 36
-text = "PAUSED"
+size_flags_vertical = 4
+theme_override_constants/separation = 20
+
+[node name="PauseMessage" type="Label" parent="PanelContainer/VBoxContainer"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 4
+text = "-  Paused -"
 metadata/_edit_lock_ = true
 
-[node name="ResumeLevelButton" type="Button" parent="PanelContainer/PauseMenuSelect"]
-custom_minimum_size = Vector2(100, 20)
+[node name="PauseMenuSelect" type="VBoxContainer" parent="PanelContainer/VBoxContainer"]
+clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 4
-focus_mode = 0
-mouse_default_cursor_shape = 2
-theme_override_font_sizes/font_size = 16
-theme_override_styles/normal = SubResource("StyleBoxFlat_2eowd")
-theme_override_styles/hover = SubResource("StyleBoxFlat_lj4oq")
-text = "RESUME"
+size_flags_vertical = 4
+theme_override_constants/separation = 20
 
-[node name="Restart" type="Button" parent="PanelContainer/PauseMenuSelect"]
-custom_minimum_size = Vector2(100, 20)
+[node name="ResumeLevelButton" type="Button" parent="PanelContainer/VBoxContainer/PauseMenuSelect"]
 layout_mode = 2
 size_flags_horizontal = 4
 focus_mode = 0
 mouse_default_cursor_shape = 2
-theme_override_font_sizes/font_size = 16
-theme_override_styles/normal = SubResource("StyleBoxFlat_qwhev")
-theme_override_styles/hover = SubResource("StyleBoxFlat_5w4ur")
-text = "RESTART"
+text = "Resume"
 
-[node name="SettingsButton" type="Button" parent="PanelContainer/PauseMenuSelect"]
-custom_minimum_size = Vector2(100, 20)
+[node name="Restart" type="Button" parent="PanelContainer/VBoxContainer/PauseMenuSelect"]
 layout_mode = 2
 size_flags_horizontal = 4
 focus_mode = 0
 mouse_default_cursor_shape = 2
-theme_override_font_sizes/font_size = 16
-theme_override_styles/normal = SubResource("StyleBoxFlat_2eowd")
-theme_override_styles/hover = SubResource("StyleBoxFlat_lj4oq")
-text = "SETTINGS"
+text = "Restart"
 
-[node name="QuitToHomeButton" type="Button" parent="PanelContainer/PauseMenuSelect"]
-custom_minimum_size = Vector2(100, 20)
+[node name="SettingsButton" type="Button" parent="PanelContainer/VBoxContainer/PauseMenuSelect"]
 layout_mode = 2
 size_flags_horizontal = 4
 focus_mode = 0
 mouse_default_cursor_shape = 2
-theme_override_font_sizes/font_size = 16
-theme_override_styles/normal = SubResource("StyleBoxFlat_qwhev")
-theme_override_styles/hover = SubResource("StyleBoxFlat_5w4ur")
-text = "QUIT"
+text = "Settings"
+
+[node name="QuitToHomeButton" type="Button" parent="PanelContainer/VBoxContainer/PauseMenuSelect"]
+layout_mode = 2
+size_flags_horizontal = 4
+focus_mode = 0
+mouse_default_cursor_shape = 2
+text = "Quit"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
@@ -213,7 +161,7 @@ libraries = {
 visible = false
 layout_mode = 1
 
-[connection signal="pressed" from="PanelContainer/PauseMenuSelect/ResumeLevelButton" to="." method="_on_resume_level_button_pressed"]
-[connection signal="pressed" from="PanelContainer/PauseMenuSelect/Restart" to="." method="_on_restart_pressed"]
-[connection signal="pressed" from="PanelContainer/PauseMenuSelect/SettingsButton" to="." method="_on_settings_button_pressed"]
-[connection signal="pressed" from="PanelContainer/PauseMenuSelect/QuitToHomeButton" to="." method="_on_quit_to_home_button_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/PauseMenuSelect/ResumeLevelButton" to="." method="_on_resume_level_button_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/PauseMenuSelect/Restart" to="." method="_on_restart_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/PauseMenuSelect/SettingsButton" to="." method="_on_settings_button_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/PauseMenuSelect/QuitToHomeButton" to="." method="_on_quit_to_home_button_pressed"]

--- a/UI/UIPauseMenu/pause_menu.gd
+++ b/UI/UIPauseMenu/pause_menu.gd
@@ -16,8 +16,13 @@ func pauseLevel():
 	$AnimationPlayer.play("blur")
 
 func restartLevel():
-	get_tree().reload_current_scene()
-	
+	var save_manager: SaveManager = get_node("/root/SaveManager")
+	var scene_manager: SceneManager = get_node("/root/SceneManager")
+
+	var save: SaveFile = save_manager.ReloadCurrentSave()
+
+	scene_manager.LoadSceneFromSave(save)
+
 func resume():
 	get_tree().paused = false
 	$AnimationPlayer.play_backwards("blur")
@@ -25,26 +30,26 @@ func resume():
 func _on_character_split(_orig_character, clone_character: Character):
 	clone = clone_character
 	clone_character.get_node("%PauseMenu").queue_free()
-	
+
 func openSettings(): #not implemented
 	settings_menu.open_settings()
 
 func quitToHome():
 	get_tree().change_scene_to_file("res://UI/UIMainMenu/MainMenu.tscn")
-	
+
 #test for keys
 func testEsc():
 	if Input.is_action_just_pressed("escape") and get_tree().paused == false:
 		pauseLevel()
 	elif Input.is_action_just_pressed("escape") and get_tree().paused == true:
 		resume()
-		
+
 func _process(_delta):
 	testEsc()
 #button signal function overrides
 func _on_resume_level_button_pressed():
 	resume()
-	
+
 func _on_settings_button_pressed():
 	openSettings()
 


### PR DESCRIPTION
Fixed the death screen and pause menu returning to the beginning of the level rather than the last checkpoint. Both the death screen and pause menu are also styled to match the game's UI theme.

In addition, if it is a new save that has not been written yet, retrying will recreate a new save (by loading the default save). This would mean reloading a new save will update its timestamp.