### PR TITLE
fix: Fix taking damage from merged clone

### DIFF
--- a/BoundingBoxes/Hitbox.cs
+++ b/BoundingBoxes/Hitbox.cs
@@ -5,8 +5,25 @@ namespace CrossedDimensions.BoundingBoxes;
 [GlobalClass]
 public partial class Hitbox : BoundingBox
 {
+    private Characters.Character _ownerCharacter;
+
     [Export]
-    public Characters.Character OwnerCharacter { get; set; }
+    public Characters.Character OwnerCharacter
+    {
+        get => _ownerCharacter;
+        set
+        {
+            _ownerCharacter = value;
+            OwnerCharacterId = value?.GetInstanceId() ?? ulong.MaxValue;
+        }
+    }
+
+    /// <summary>
+    /// The instance ID of the owner character, used for hit detection to avoid
+    /// hitting the owner or its clones/mirrors. Set automatically when
+    /// <see cref="OwnerCharacter"/> is set.
+    /// </summary>
+    public ulong OwnerCharacterId { get; private set; }
 
     [Export]
     public Components.DamageComponent DamageComponent { get; set; }

--- a/BoundingBoxes/Hurtbox.cs
+++ b/BoundingBoxes/Hurtbox.cs
@@ -74,6 +74,11 @@ public partial class Hurtbox : BoundingBox
                         return true;
                     }
                 }
+
+                if (OwnerCharacter.Cloneable.LastMirrorId == hitbox.OwnerCharacterId)
+                {
+                    return true;
+                }
             }
         }
 

--- a/BoundingBoxes/Hurtbox.cs
+++ b/BoundingBoxes/Hurtbox.cs
@@ -75,7 +75,8 @@ public partial class Hurtbox : BoundingBox
                     }
                 }
 
-                if (OwnerCharacter.Cloneable.LastMirrorId == hitbox.OwnerCharacterId)
+                if (OwnerCharacter.Cloneable.LastMirrorId != ulong.MaxValue
+                    && OwnerCharacter.Cloneable.LastMirrorId == hitbox.OwnerCharacterId)
                 {
                     return true;
                 }

--- a/Characters/CloneableComponent.cs
+++ b/Characters/CloneableComponent.cs
@@ -155,6 +155,7 @@ public sealed partial class CloneableComponent : Node
             return null;
         }
 
+        LastMirrorId = ulong.MaxValue;
         HealingPool = 0f;
 
         var clone = (Character)Character.Duplicate();

--- a/Characters/CloneableComponent.cs
+++ b/Characters/CloneableComponent.cs
@@ -46,6 +46,13 @@ public sealed partial class CloneableComponent : Node
     /// </summary>
     public Character Mirror => Original ?? Clone;
 
+    /// <summary>
+    /// The instance ID of the most recent mirror before the last merge.
+    /// Used to prevent self-damage from in-flight projectiles fired just
+    /// before merging, whose OwnerCharacter node may now be freed.
+    /// </summary>
+    public ulong LastMirrorId { get; private set; } = ulong.MaxValue;
+
     /// <returns>
     /// <c>true</c> if this character is a clone; otherwise, <c>false</c>.
     /// </returns>
@@ -237,6 +244,7 @@ public sealed partial class CloneableComponent : Node
             int health = Character.Health.CurrentHealth + Mirror.Health.CurrentHealth;
 
             Character.Health.SetStats(health, maxHealth);
+            LastMirrorId = Mirror.GetInstanceId();
             Clone.QueueFree();
             Clone = null;
         }

--- a/CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs
+++ b/CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs
@@ -194,4 +194,42 @@ public class HurtboxTest(GodotHeadlessFixedFpsFixture godot)
 
         hurtbox.ShouldIgnoreHitFrom(hitbox).ShouldBeFalse();
     }
+
+    [Fact]
+    public void Hurtbox_ShouldIgnoreHitFrom_ReturnsTrueWhenHitboxOwnerIdMatchesLastMirrorId()
+    {
+        var packed = ResourceLoader.Load<PackedScene>("res://Characters/Character.tscn");
+        var scene = new Node2D();
+        var original = packed.Instantiate<Character>();
+        scene.AddChild(original);
+        godot.Tree.Root.AddChild(scene);
+
+        var clone = original.Cloneable.Split();
+        var cloneId = clone.GetInstanceId();
+
+        var hurtbox = new Hurtbox
+        {
+            OwnerCharacter = original,
+            HealthComponent = original.Health,
+        };
+        var hitbox = new Hitbox
+        {
+            DamageComponent = new DamageComponent(),
+        };
+
+        hitbox.OwnerCharacter = clone;
+
+        original.Cloneable.Merge();
+        godot.GodotInstance.Iteration(1);
+
+        original.Cloneable.LastMirrorId.ShouldBe(cloneId);
+        Node.IsInstanceIdValid(cloneId).ShouldBeFalse();
+        hitbox.OwnerCharacter.ShouldNotBeNull();
+        hitbox.OwnerCharacterId.ShouldBe(cloneId);
+
+        hurtbox.ShouldIgnoreHitFrom(hitbox).ShouldBeTrue();
+
+        scene.QueueFree();
+        hitbox.QueueFree();
+    }
 }

--- a/CrossedDimensions.Tests/Integration/CloneableComponentIntegrationTest.cs
+++ b/CrossedDimensions.Tests/Integration/CloneableComponentIntegrationTest.cs
@@ -120,6 +120,30 @@ public class CloneableComponentIntegrationTest : IDisposable
     }
 
     [Fact]
+    public void CloneableComponent_Merge_ShouldStoreLastMirrorId()
+    {
+        var clone = _character.Cloneable.Split();
+        var cloneId = clone.GetInstanceId();
+
+        _character.Cloneable.Merge();
+
+        _character.Cloneable.LastMirrorId.ShouldBe(cloneId);
+    }
+
+    [Fact]
+    public void CloneableComponent_Split_ShouldResetLastMirrorId()
+    {
+        var clone = _character.Cloneable.Split();
+        _character.Cloneable.Merge();
+
+        _character.Cloneable.LastMirrorId.ShouldBe(clone.GetInstanceId());
+
+        _character.Cloneable.Split();
+
+        _character.Cloneable.LastMirrorId.ShouldBe(ulong.MaxValue);
+    }
+
+    [Fact]
     public void CloneableComponent_Merge_WhenCalledOnClone_ShouldFreeItself()
     {
         var clone = _character.Cloneable.Split();


### PR DESCRIPTION
This pull request introduces improvements to hit detection logic for characters with clone or mirror mechanics, ensuring that self-inflicted damage from projectiles is correctly ignored, even after merging. The changes revolve around tracking the instance ID of the last mirror and updating hitbox ownership accordingly.

**Hit detection and ownership tracking improvements:**

* The `Hitbox` class now manages an `OwnerCharacterId` property, which is automatically updated whenever `OwnerCharacter` is set. This helps uniquely identify the owner for hit detection purposes.
* The `CloneableComponent` class introduces a `LastMirrorId` property to keep track of the most recent mirror's instance ID before a merge, preventing self-damage from projectiles fired just before merging. The property is updated during the merge process. [[1]](diffhunk://#diff-5784dbc570d7a75a5f7c5ffb35c1bf079d275d0e635db1b4461a5c2b6bacfbbeR49-R55) [[2]](diffhunk://#diff-5784dbc570d7a75a5f7c5ffb35c1bf079d275d0e635db1b4461a5c2b6bacfbbeR247)

**Hit detection logic enhancements:**

* The `Hurtbox` class's `ShouldIgnoreHitFrom` method now checks if the incoming hitbox's `OwnerCharacterId` matches the attacker's `LastMirrorId`, ensuring hits from projectiles fired by a character's previous mirror are ignored after merging.