### PR TITLE
feature: Serialize inventory in savefile

### DIFF
--- a/BoundingBoxes/GiveItemArea.gd
+++ b/BoundingBoxes/GiveItemArea.gd
@@ -12,9 +12,12 @@ func _on_body_entered(body: Node) -> void:
 	if body.is_in_group("Player"):
 		print("Player collided with item area")
 		if item_scene:
+			var inventory: InventoryComponent = body.Inventory
+			if inventory.HasWeaponFromScene(item_scene):
+				queue_free()
+				return
 			print("Giving item to player")
 			var item_instance = item_scene.instantiate()
-			var inventory: InventoryComponent = body.Inventory
 			inventory.add_child(item_instance)
 			inventory.EquipWeapon(item_instance, true)
 			queue_free()

--- a/Components/InventoryComponent.cs
+++ b/Components/InventoryComponent.cs
@@ -1,9 +1,9 @@
 using System.Linq;
 using Godot;
-using Godot.Collections;
 using CrossedDimensions.Characters;
 using CrossedDimensions.Items;
 using CrossedDimensions.Extensions;
+using CrossedDimensions.Saves;
 
 namespace CrossedDimensions.Components;
 
@@ -15,6 +15,8 @@ namespace CrossedDimensions.Components;
 [GlobalClass]
 public partial class InventoryComponent : Node2D
 {
+    private bool _suppressSavePersistence;
+
     /// <summary>
     /// Emitted when the equipped weapon changes. Provides the previous and the
     /// currently equipped weapon (either may be null).
@@ -79,13 +81,34 @@ public partial class InventoryComponent : Node2D
 
         ChildEnteredTree += OnChildEnteredTree;
 
-        // on ready, auto-equip the first weapon if we have one and don't already
-        if (EquippedWeapon is null)
+        bool isOriginalCharacter = OwnerCharacter is not null && OwnerCharacter.Cloneable?.Original is null;
+        if (isOriginalCharacter)
         {
-            var firstWeapon = GetChildren().OfType<Weapon>().FirstOrDefault();
-            if (firstWeapon is not null)
+            _suppressSavePersistence = true;
+        }
+
+        try
+        {
+            // on ready, auto-equip the first weapon if we have one and don't already
+            if (EquippedWeapon is null)
             {
-                EquipWeapon(firstWeapon, recursive: false);
+                var firstWeapon = GetChildren().OfType<Weapon>().FirstOrDefault();
+                if (firstWeapon is not null)
+                {
+                    EquipWeapon(firstWeapon, recursive: false);
+                }
+            }
+
+            if (isOriginalCharacter)
+            {
+                LoadFromSave(SaveManager.Instance?.CurrentSave);
+            }
+        }
+        finally
+        {
+            if (isOriginalCharacter)
+            {
+                _suppressSavePersistence = false;
             }
         }
     }
@@ -104,12 +127,12 @@ public partial class InventoryComponent : Node2D
             // auto-equip first weapon on pickup. NOTE: this does not handle
             // the case where the player character starts with the weapon
             // on ready.
-            if (EquippedWeapon is null && EquippedWeapon.GetParent() == this)
+            if (EquippedWeapon is null && weapon.GetParent() == this)
             {
                 EquipWeapon(weapon);
             }
 
-            if (OwnerCharacter.Cloneable?.Mirror is not null)
+            if (OwnerCharacter?.Cloneable?.Mirror is not null)
             {
                 var clone = OwnerCharacter.Cloneable.Mirror;
                 if (!clone.Inventory.HasNode(new NodePath(weapon.Name)))
@@ -118,6 +141,11 @@ public partial class InventoryComponent : Node2D
                     GD.Print($"Adding weapon clone {weaponClone.Name} to clone inventory");
                     clone.Inventory.AddChild(weaponClone);
                 }
+            }
+
+            if (!_suppressSavePersistence && OwnerCharacter is not null && OwnerCharacter.Cloneable?.Original is null)
+            {
+                PersistToSave(SaveManager.Instance?.CurrentSave);
             }
         }
     }
@@ -234,6 +262,11 @@ public partial class InventoryComponent : Node2D
             oldIndex,
             EquippedWeapon,
             newIndex);
+
+        if (!_suppressSavePersistence && OwnerCharacter is not null && OwnerCharacter.Cloneable?.Original is null)
+        {
+            PersistToSave(SaveManager.Instance?.CurrentSave);
+        }
     }
 
     /// <summary>
@@ -270,5 +303,118 @@ public partial class InventoryComponent : Node2D
         {
             EquipWeapon(weapon, recursive);
         }
+    }
+
+    public Godot.Collections.Array<string> GetWeaponScenePaths()
+    {
+        var paths = new Godot.Collections.Array<string>();
+
+        foreach (var weapon in GetChildren().OfType<Weapon>())
+        {
+            var path = GetWeaponScenePath(weapon);
+            if (!string.IsNullOrEmpty(path))
+            {
+                paths.Add(path);
+            }
+        }
+
+        return paths;
+    }
+
+    public bool HasWeaponFromScene(PackedScene scene)
+    {
+        if (scene is null)
+        {
+            return false;
+        }
+
+        return HasWeaponFromScenePath(scene.ResourcePath);
+    }
+
+    internal void LoadFromSave(SaveFile save)
+    {
+        if (save is null || !save.KeyValue.ContainsKey("inventory_weapons"))
+        {
+            return;
+        }
+
+        bool wasSuppressed = _suppressSavePersistence;
+        _suppressSavePersistence = true;
+        try
+        {
+            foreach (var path in save.InventoryWeapons)
+            {
+                if (string.IsNullOrEmpty(path) || HasWeaponFromScenePath(path))
+                {
+                    continue;
+                }
+
+                var packedScene = ResourceLoader.Load<PackedScene>(path);
+                if (packedScene is null)
+                {
+                    GD.PushWarning($"InventoryComponent.LoadFromSave: failed to load '{path}'.");
+                    continue;
+                }
+
+                var weapon = packedScene.Instantiate<Weapon>();
+                if (weapon is null)
+                {
+                    GD.PushWarning($"InventoryComponent.LoadFromSave: scene '{path}' is not a Weapon.");
+                    continue;
+                }
+
+                AddChild(weapon);
+            }
+
+            EquipWeaponByIndex(save.InventoryEquippedIndex);
+        }
+        finally
+        {
+            _suppressSavePersistence = wasSuppressed;
+        }
+    }
+
+    internal void PersistToSave(SaveFile save)
+    {
+        if (save is null)
+        {
+            return;
+        }
+
+        save.InventoryWeapons = GetWeaponScenePaths();
+
+        var weapons = GetChildren().OfType<Weapon>().ToList();
+        int equippedIndex = EquippedWeapon is null
+            ? -1
+            : weapons.IndexOf(EquippedWeapon);
+
+        save.InventoryEquippedIndex = equippedIndex;
+    }
+
+    private bool HasWeaponFromScenePath(string scenePath)
+    {
+        return GetChildren()
+            .OfType<Weapon>()
+            .Any(weapon => GetWeaponScenePath(weapon) == scenePath);
+    }
+
+    private static string GetWeaponScenePath(Weapon weapon)
+    {
+        if (weapon is null)
+        {
+            return string.Empty;
+        }
+
+        if (!string.IsNullOrEmpty(weapon.SceneFilePath))
+        {
+            return weapon.SceneFilePath;
+        }
+
+        if (weapon.HasMeta("scene_file_path"))
+        {
+            return weapon.GetMeta("scene_file_path").AsString();
+        }
+
+        return string.Empty;
     }
 }

--- a/CrossedDimensions.Tests/Components/InventoryComponentTest.cs
+++ b/CrossedDimensions.Tests/Components/InventoryComponentTest.cs
@@ -1,11 +1,17 @@
+using System.Linq;
 using CrossedDimensions.Components;
 using CrossedDimensions.Items;
+using CrossedDimensions.Saves;
+using Godot;
 
 namespace CrossedDimensions.Tests.Components;
 
 [Collection("GodotHeadless")]
 public class InventoryComponentTest(GodotHeadlessFixedFpsFixture godot)
 {
+    private const string RocketLauncherPath = "res://Items/RocketLauncher.tscn";
+    private const string PelletShooterPath = "res://Items/PelletShooter.tscn";
+
     [Fact]
     public void Ready_ShouldEquipAnyWeapon()
     {
@@ -127,5 +133,81 @@ public class InventoryComponentTest(GodotHeadlessFixedFpsFixture godot)
 
         inventory.CycleWeapon(1);
         inventory.EquippedWeapon.ShouldBeNull();
+    }
+
+    [Fact]
+    public void LoadFromSave_WhenSaveHasNoInventoryKey_DoesNothing()
+    {
+        var inventory = new InventoryComponent();
+        var save = new SaveFile();
+
+        inventory.LoadFromSave(save);
+
+        inventory.GetChildren().OfType<Weapon>().Count().ShouldBe(0);
+        inventory.EquippedWeapon.ShouldBeNull();
+    }
+
+    [Fact]
+    public void LoadFromSave_WhenSaveHasWeapons_AddsAndEquipsByIndex()
+    {
+        var inventory = new InventoryComponent();
+        var save = new SaveFile
+        {
+            InventoryWeapons = new Godot.Collections.Array<string>
+            {
+                PelletShooterPath,
+                RocketLauncherPath,
+            },
+            InventoryEquippedIndex = 1,
+        };
+
+        inventory.LoadFromSave(save);
+
+        var weapons = inventory.GetChildren().OfType<Weapon>().ToList();
+        weapons.Count.ShouldBe(2);
+        inventory.EquippedWeapon.ShouldBe(weapons[1]);
+        inventory.EquippedWeapon.SceneFilePath.ShouldBe(RocketLauncherPath);
+    }
+
+    [Fact]
+    public void LoadFromSave_WhenWeaponAlreadyExists_SkipsDuplicate()
+    {
+        var inventory = new InventoryComponent();
+        var existing = ResourceLoader
+            .Load<PackedScene>(RocketLauncherPath)
+            .Instantiate<Weapon>();
+        inventory.AddChild(existing);
+
+        var save = new SaveFile
+        {
+            InventoryWeapons = new Godot.Collections.Array<string> { RocketLauncherPath },
+            InventoryEquippedIndex = 0,
+        };
+
+        inventory.LoadFromSave(save);
+
+        inventory.GetChildren().OfType<Weapon>().Count().ShouldBe(1);
+    }
+
+    [Fact]
+    public void PersistToSave_StoresWeaponPathsAndEquippedIndex()
+    {
+        var inventory = new InventoryComponent();
+        var weaponA = new Weapon();
+        weaponA.SetMeta("scene_file_path", PelletShooterPath);
+        var weaponB = new Weapon();
+        weaponB.SetMeta("scene_file_path", RocketLauncherPath);
+        inventory.AddChild(weaponA);
+        inventory.AddChild(weaponB);
+        inventory.EquipWeapon(weaponB, recursive: false);
+
+        var save = new SaveFile();
+
+        inventory.PersistToSave(save);
+
+        save.InventoryWeapons.Count.ShouldBe(2);
+        save.InventoryWeapons[0].ShouldBe(PelletShooterPath);
+        save.InventoryWeapons[1].ShouldBe(RocketLauncherPath);
+        save.InventoryEquippedIndex.ShouldBe(1);
     }
 }

--- a/CrossedDimensions.Tests/Integration/CharacterInventoryIntegrationTest.cs
+++ b/CrossedDimensions.Tests/Integration/CharacterInventoryIntegrationTest.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using CrossedDimensions.Characters;
+using CrossedDimensions.Saves;
 using Godot;
 using twodog.xunit;
 using Xunit;
@@ -222,5 +224,39 @@ public class CharacterInventoryIntegrationTest : IDisposable
             .ShouldBe(_rocketLauncher2.Name.ToString());
         clone.Inventory.EquippedWeapon.Name.ToString()
             .ShouldBe(_rocketLauncher1.Name.ToString());
+    }
+
+    [Fact]
+    public void GivenWeaponPickup_WhenCharacterIsReinstanced_ThenWeaponLoadsFromInMemorySave()
+    {
+        var previousSaveManager = SaveManager.Instance;
+        var saveManager = new SaveManager();
+        _godot.Tree.Root.AddChild(saveManager);
+        saveManager.CurrentSave = new SaveFile();
+
+        var characterScene = ResourceLoader.Load<PackedScene>("res://Characters/Character.tscn");
+        var firstCharacter = characterScene.Instantiate<Character>();
+        _godot.Tree.Root.AddChild(firstCharacter);
+
+        var rocketScenePath = "res://Items/RocketLauncher.tscn";
+        var rocketPickup = ResourceLoader.Load<PackedScene>(rocketScenePath).Instantiate<Weapon>();
+        firstCharacter.Inventory.AddChild(rocketPickup);
+        firstCharacter.Inventory.EquipWeapon(rocketPickup, recursive: false);
+
+        saveManager.CurrentSave.InventoryWeapons.ShouldContain(rocketScenePath);
+
+        firstCharacter.QueueFree();
+
+        var secondCharacter = characterScene.Instantiate<Character>();
+        _godot.Tree.Root.AddChild(secondCharacter);
+
+        secondCharacter.Inventory
+            .GetWeaponScenePaths()
+            .ToArray()
+            .ShouldContain(rocketScenePath);
+
+        secondCharacter.QueueFree();
+        saveManager.QueueFree();
+        SaveManager.Instance = previousSaveManager;
     }
 }

--- a/CrossedDimensions.Tests/Saves/SaveFileTest.cs
+++ b/CrossedDimensions.Tests/Saves/SaveFileTest.cs
@@ -63,4 +63,31 @@ public class SaveFileTest(GodotHeadlessFixedFpsFixture godot)
         var result = save.GetKeyOrDefault<int>("missing", 42);
         result.ShouldBe(42);
     }
+
+    [Fact]
+    public void InventoryWeapons_WhenMissingKey_ReturnsEmptyArray()
+    {
+        var save = new SaveFile();
+
+        save.InventoryWeapons.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void InventoryProperties_RoundTripValues()
+    {
+        var save = new SaveFile();
+        var weapons = new Godot.Collections.Array<string>
+        {
+            "res://Items/PelletShooter.tscn",
+            "res://Items/RocketLauncher.tscn",
+        };
+
+        save.InventoryWeapons = weapons;
+        save.InventoryEquippedIndex = 1;
+
+        save.InventoryWeapons.Count.ShouldBe(2);
+        save.InventoryWeapons[0].ShouldBe("res://Items/PelletShooter.tscn");
+        save.InventoryWeapons[1].ShouldBe("res://Items/RocketLauncher.tscn");
+        save.InventoryEquippedIndex.ShouldBe(1);
+    }
 }

--- a/Saves/SaveFile.cs
+++ b/Saves/SaveFile.cs
@@ -54,6 +54,18 @@ public partial class SaveFile : Resource
         set => SetKey("player_scene", value);
     }
 
+    public Godot.Collections.Array<string> InventoryWeapons
+    {
+        get => TryGetKey<Godot.Collections.Array<string>>("inventory_weapons", out var v) ? v : new();
+        set => SetKey("inventory_weapons", value);
+    }
+
+    public int InventoryEquippedIndex
+    {
+        get => GetKeyOrDefault<int>("inventory_equipped_index", -1);
+        set => SetKey("inventory_equipped_index", value);
+    }
+
     /// <summary>
     /// Generic key/value store for arbitrary game flags and small pieces of state.
     /// Keys are strings and values are Godot Variants (bool, int, float, string, etc.).


### PR DESCRIPTION
Adds reading inventory state from savefile and writing to savefile. On scene load, the player's inventory is populated with items from the savefile. Whenever the inventory changes, the items are serialized onto the savefile. Note that this modifies the in-memory savefile, and these modifications do not persist until the player interacts with a savepoint to persist to disk. Closes #228 

---

Copilot summary:

This pull request introduces persistent inventory support for weapons, allowing a character's weapon inventory and equipped weapon to be saved and restored across sessions or scene reloads. The changes add save/load logic to the `InventoryComponent`, update the save file structure, and provide comprehensive tests to ensure correct behavior.

**Inventory persistence and save/load logic:**

* Added `InventoryWeapons` and `InventoryEquippedIndex` properties to `SaveFile`, enabling storage and retrieval of weapon scene paths and equipped weapon index.
* Implemented `LoadFromSave` and `PersistToSave` methods in `InventoryComponent` to handle restoring and saving the inventory state from/to a `SaveFile`. These methods ensure no duplicates, handle missing or invalid data gracefully, and suppress recursive save triggers during load.
* Modified the `InventoryComponent` lifecycle so that original characters automatically load inventory from the current save on ready, and persist changes when weapons are added or equipped. [[1]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6R84-R91) [[2]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6R101-R113) [[3]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6L107-R135) [[4]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6R145-R149) [[5]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6R265-R269) [[6]](diffhunk://#diff-eb59f301188de22e26579b7b452424250bd9a98fd0ac43aac87178ebd0f10ec6R18-R19)

**Gameplay logic improvements:**

* Updated `GiveItemArea.gd` to prevent giving duplicate weapons to the player by checking if the inventory already contains the weapon scene before instantiating and adding it.

**Testing and validation:**

* Added extensive unit and integration tests for inventory save/load, duplicate prevention, and round-trip persistence of weapon data and equipped index. [[1]](diffhunk://#diff-060ef2df29b7a2ad0930dd63a4b8b163c0ca1ff1838c20f20b6f919f0f024005R1-R14) [[2]](diffhunk://#diff-060ef2df29b7a2ad0930dd63a4b8b163c0ca1ff1838c20f20b6f919f0f024005R137-R212) [[3]](diffhunk://#diff-5a440b5a7ede027ee8dd0a0fc240ab67bf8778bfe4a4b312a199119aecf4941aR66-R92) [[4]](diffhunk://#diff-c4bd61d626a2209fac23b2c3670347c901f57b5e91b30b1d13319ab49b223605R2-R4) [[5]](diffhunk://#diff-c4bd61d626a2209fac23b2c3670347c901f57b5e91b30b1d13319ab49b223605R228-R261)

These changes ensure that weapon pickups, equipping, and inventory management are robust and persist correctly between game sessions.