### PR TITLE
feature: Add scene name trigger

### DIFF
--- a/Assets/AreaData/CaveLevel.tres
+++ b/Assets/AreaData/CaveLevel.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="AreaData" load_steps=2 format=3 uid="uid://c3vhh51331d5d"]
+
+[ext_resource type="Script" uid="uid://bgc44hje0lo1q" path="res://Environment/AreaData.cs" id="1_jen0i"]
+
+[resource]
+script = ExtResource("1_jen0i")
+Title = "The Chasm"
+Subtitle = "Home, for those who dare descend."
+metadata/_custom_type_script = "uid://bgc44hje0lo1q"

--- a/Assets/AreaData/IceLevel.tres
+++ b/Assets/AreaData/IceLevel.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" script_class="AreaData" load_steps=2 format=3 uid="uid://ccwojb7uocpof"]
+
+[ext_resource type="Script" uid="uid://bgc44hje0lo1q" path="res://Environment/AreaData.cs" id="1_usqvi"]
+
+[resource]
+script = ExtResource("1_usqvi")
+Title = "The Frost Seam"
+Subtitle = "Ancient aether given form, frozen in time."
+metadata/_custom_type_script = "uid://bgc44hje0lo1q"

--- a/CrossedDimensions.Tests/Environment/AreaManagerTest.cs
+++ b/CrossedDimensions.Tests/Environment/AreaManagerTest.cs
@@ -1,0 +1,35 @@
+using CrossedDimensions.Environment;
+using Shouldly;
+using Xunit;
+
+namespace CrossedDimensions.Tests.Environment;
+
+ [Collection("GodotHeadless")]
+public class AreaManagerTest
+{
+    private readonly GodotHeadlessFixedFpsFixture _godot;
+
+    public AreaManagerTest(GodotHeadlessFixedFpsFixture godot)
+    {
+        _godot = godot;
+    }
+
+    [Fact]
+    public void NotifyAreaTitleTriggerEntered_WithAreaData_EmitsSignal()
+    {
+        var manager = new AreaManager();
+        var data = new AreaData
+        {
+            Title = "Crystal Peak",
+            Subtitle = "Whispering Ridges"
+        };
+
+        AreaData emitted = null;
+        manager.AreaTriggerEntered += areaData => emitted = areaData;
+
+        manager.NotifyAreaTitleTriggerEntered(data);
+
+        emitted.ShouldNotBeNull();
+        emitted.ShouldBeSameAs(data);
+    }
+}

--- a/CrossedDimensions.Tests/Integration/Environment/AreaTitleTriggerIntegrationTest.cs
+++ b/CrossedDimensions.Tests/Integration/Environment/AreaTitleTriggerIntegrationTest.cs
@@ -1,0 +1,189 @@
+using CrossedDimensions.Characters;
+using CrossedDimensions.Environment;
+using CrossedDimensions.Environment.Triggers;
+using CrossedDimensions.UI.UIPlayerHud;
+using Godot;
+using Shouldly;
+using Xunit;
+
+namespace CrossedDimensions.Tests.Integration.Environment;
+
+[Collection("GodotHeadless")]
+public sealed class AreaTitleTriggerIntegrationTest : System.IDisposable
+{
+    private const string CharacterScenePath = "res://Characters/Character.tscn";
+    private const string AreaTitleCardScenePath = "res://UI/UIPlayerHud/AreaTitleCard.tscn";
+
+    private readonly GodotHeadlessFixedFpsFixture _godot;
+    private readonly Node _sceneRoot;
+    private readonly AreaManager _areaManager;
+    private readonly Character _player;
+    private readonly AreaTitleCard _areaTitleCard;
+
+    public AreaTitleTriggerIntegrationTest(GodotHeadlessFixedFpsFixture godot)
+    {
+        _godot = godot;
+        _sceneRoot = new Node { Name = "area_title_trigger_test_root" };
+        _godot.Tree.Root.AddChild(_sceneRoot);
+
+        _areaManager = new AreaManager { Name = "area_manager" };
+        _godot.Tree.Root.AddChild(_areaManager);
+
+        _areaTitleCard = ResourceLoader
+            .Load<PackedScene>(AreaTitleCardScenePath)
+            .Instantiate<AreaTitleCard>();
+        _sceneRoot.AddChild(_areaTitleCard);
+
+        _player = ResourceLoader
+            .Load<PackedScene>(CharacterScenePath)
+            .Instantiate<Character>();
+        _sceneRoot.AddChild(_player);
+
+        _godot.GodotInstance.Iteration(2);
+    }
+
+    public void Dispose()
+    {
+        _sceneRoot?.QueueFree();
+        _areaManager?.QueueFree();
+    }
+
+    [Fact]
+    public void AreaTitleTrigger_WhenPlayerEnters_EmitsAreaManagerSignal()
+    {
+        var areaData = new AreaData
+        {
+            Title = "Fungal Core",
+            Subtitle = "Collapsed Galleries"
+        };
+
+        var trigger = CreateTrigger(areaData);
+
+        var signalCount = 0;
+        AreaData emittedData = null;
+        _areaManager.AreaTriggerEntered += data =>
+        {
+            signalCount++;
+            emittedData = data;
+        };
+
+        trigger.EmitSignal(Area2D.SignalName.BodyEntered, _player);
+        _godot.GodotInstance.Iteration(1);
+
+        signalCount.ShouldBe(1);
+        emittedData.ShouldBeSameAs(areaData);
+    }
+
+    [Fact]
+    public void AreaTitleTrigger_WhenCloneEnters_DoesNotEmitAreaManagerSignal()
+    {
+        var areaData = new AreaData
+        {
+            Title = "Fungal Core",
+            Subtitle = "Collapsed Galleries"
+        };
+
+        var trigger = CreateTrigger(areaData);
+        var clone = CreateClone();
+
+        var signalCount = 0;
+        _areaManager.AreaTriggerEntered += _ => signalCount++;
+
+        trigger.EmitSignal(Area2D.SignalName.BodyEntered, clone);
+        _godot.GodotInstance.Iteration(1);
+
+        signalCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void AreaTitleCard_WhenEnteringSameAreaData_DoesNotRestartAnimation()
+    {
+        var first = new AreaData
+        {
+            Title = "Faded Canyon",
+            Subtitle = "Dust Corridor"
+        };
+
+        var sameByValue = new AreaData
+        {
+            Title = "Faded Canyon",
+            Subtitle = "Dust Corridor"
+        };
+
+        var firstTrigger = CreateTrigger(first);
+        var secondTrigger = CreateTrigger(sameByValue);
+
+        firstTrigger.EmitSignal(Area2D.SignalName.BodyEntered, _player);
+        _godot.GodotInstance.Iteration(1);
+
+        _areaTitleCard.AnimationPlayCount.ShouldBe(1);
+
+        _godot.GodotInstance.Iteration(10);
+
+        secondTrigger.EmitSignal(Area2D.SignalName.BodyEntered, _player);
+        _godot.GodotInstance.Iteration(1);
+
+        _areaTitleCard.TitleLabel.Text.ShouldBe("Faded Canyon");
+        _areaTitleCard.SubtitleLabel.Text.ShouldBe("Dust Corridor");
+        _areaTitleCard.AnimationPlayCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void AreaTitleCard_WhenEnteringDifferentAreaData_RestartsAnimationAndUpdatesText()
+    {
+        var first = new AreaData
+        {
+            Title = "Stone Reach",
+            Subtitle = "Outer Ramparts"
+        };
+
+        var second = new AreaData
+        {
+            Title = "Sunken Vault",
+            Subtitle = "Flooded Annex"
+        };
+
+        var firstTrigger = CreateTrigger(first);
+        var secondTrigger = CreateTrigger(second);
+
+        firstTrigger.EmitSignal(Area2D.SignalName.BodyEntered, _player);
+        _godot.GodotInstance.Iteration(1);
+
+        _areaTitleCard.AnimationPlayCount.ShouldBe(1);
+
+        _godot.GodotInstance.Iteration(10);
+
+        secondTrigger.EmitSignal(Area2D.SignalName.BodyEntered, _player);
+        _godot.GodotInstance.Iteration(1);
+
+        _areaTitleCard.TitleLabel.Text.ShouldBe("Sunken Vault");
+        _areaTitleCard.SubtitleLabel.Text.ShouldBe("Flooded Annex");
+        _areaTitleCard.AnimationPlayCount.ShouldBe(2);
+    }
+
+    private AreaTitleTrigger CreateTrigger(AreaData areaData)
+    {
+        var trigger = new AreaTitleTrigger
+        {
+            AreaData = areaData,
+            Name = $"area_title_trigger_{areaData.Title.Replace(' ', '_')}"
+        };
+
+        _sceneRoot.AddChild(trigger);
+        _godot.GodotInstance.Iteration(1);
+        return trigger;
+    }
+
+    private Character CreateClone()
+    {
+        var original = ResourceLoader
+            .Load<PackedScene>(CharacterScenePath)
+            .Instantiate<Character>();
+
+        _sceneRoot.AddChild(original);
+        _godot.GodotInstance.Iteration(1);
+        var clone = original.Cloneable.Split();
+        _godot.GodotInstance.Iteration(1);
+        return clone;
+    }
+}

--- a/Environment/AreaData.cs
+++ b/Environment/AreaData.cs
@@ -1,0 +1,13 @@
+using Godot;
+
+namespace CrossedDimensions.Environment;
+
+[GlobalClass]
+public partial class AreaData : Resource
+{
+    [Export]
+    public string Title { get; set; } = "";
+
+    [Export]
+    public string Subtitle { get; set; } = "";
+}

--- a/Environment/AreaData.cs.uid
+++ b/Environment/AreaData.cs.uid
@@ -1,0 +1,1 @@
+uid://bgc44hje0lo1q

--- a/Environment/AreaManager.cs
+++ b/Environment/AreaManager.cs
@@ -1,0 +1,27 @@
+using Godot;
+
+namespace CrossedDimensions.Environment;
+
+[GlobalClass]
+public partial class AreaManager : Node
+{
+    public static AreaManager Instance { get; private set; }
+
+    [Signal]
+    public delegate void AreaTriggerEnteredEventHandler(AreaData data);
+
+    public override void _Ready()
+    {
+        Instance = this;
+    }
+
+    public void NotifyAreaTitleTriggerEntered(AreaData data)
+    {
+        if (data is null)
+        {
+            return;
+        }
+
+        EmitSignal(SignalName.AreaTriggerEntered, data);
+    }
+}

--- a/Environment/AreaManager.cs.uid
+++ b/Environment/AreaManager.cs.uid
@@ -1,0 +1,1 @@
+uid://dx25gkm3c5a0l

--- a/Environment/Triggers/AreaTitleTrigger.cs
+++ b/Environment/Triggers/AreaTitleTrigger.cs
@@ -1,0 +1,42 @@
+using CrossedDimensions.Environment;
+using Godot;
+
+namespace CrossedDimensions.Environment.Triggers;
+
+[GlobalClass]
+public partial class AreaTitleTrigger : Area2D
+{
+    [Export]
+    public AreaData AreaData { get; set; }
+
+    public override void _Ready()
+    {
+        BodyEntered += OnBodyEntered;
+    }
+
+    public override void _ExitTree()
+    {
+        BodyEntered -= OnBodyEntered;
+    }
+
+    private void OnBodyEntered(Node body)
+    {
+        if (body is not Characters.Character character)
+        {
+            return;
+        }
+
+        if (character.Cloneable?.IsClone ?? true)
+        {
+            return;
+        }
+
+        if (AreaData is null)
+        {
+            GD.PushWarning($"AreaTitleTrigger '{Name}' does not have AreaData assigned.");
+            return;
+        }
+
+        AreaManager.Instance?.NotifyAreaTitleTriggerEntered(AreaData);
+    }
+}

--- a/Environment/Triggers/AreaTitleTrigger.cs.uid
+++ b/Environment/Triggers/AreaTitleTrigger.cs.uid
@@ -1,0 +1,1 @@
+uid://1okeb4x0c0oe

--- a/Saves/SceneManager.cs
+++ b/Saves/SceneManager.cs
@@ -192,13 +192,13 @@ public partial class SceneManager : Node
         GetTree().ChangeSceneToPacked(packed);
         await ToSignal(GetTree(), SceneTree.SignalName.SceneChanged);
 
+        onSceneReady?.Invoke();
+
         if (fade)
         {
             GetTree().Paused = false;
             await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
         }
-
-        onSceneReady?.Invoke();
 
         if (fade)
         {

--- a/Scenes/CaveLevel.tscn
+++ b/Scenes/CaveLevel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=62 format=4 uid="uid://xomrpt6tpnwh"]
+[gd_scene load_steps=67 format=4 uid="uid://xomrpt6tpnwh"]
 
 [ext_resource type="TileSet" uid="uid://dcum4ve6n64ps" path="res://Assets/CaveLevelTileset.tres" id="1_la4x4"]
 [ext_resource type="Texture2D" uid="uid://cti1j4t0t7abe" path="res://Assets/Textures/cave-background.png" id="1_ndns7"]
@@ -39,6 +39,8 @@
 [ext_resource type="Texture2D" uid="uid://idvntlbib36b" path="res://Assets/Textures/Props/Cave Sign.png" id="23_5rwqa"]
 [ext_resource type="Script" uid="uid://dh4w3aintnbw6" path="res://BoundingBoxes/SceneTransitionTrigger.cs" id="34_6vyi0"]
 [ext_resource type="Script" uid="uid://b8d5jsltwqpjb" path="res://BoundingBoxes/CameraBoundsTrigger.cs" id="35_aqto1"]
+[ext_resource type="Script" uid="uid://1okeb4x0c0oe" path="res://Environment/Triggers/AreaTitleTrigger.cs" id="36_y4r3f"]
+[ext_resource type="Resource" uid="uid://c3vhh51331d5d" path="res://Assets/AreaData/CaveLevel.tres" id="37_xdbyy"]
 
 [sub_resource type="Environment" id="Environment_1wd8j"]
 background_mode = 3
@@ -129,11 +131,18 @@ size = Vector2(768, 768)
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_s00wl"]
 size = Vector2(512, 256)
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_xdbyy"]
+
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_aqto1"]
 size = Vector2(64, 64)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jkq6g"]
 size = Vector2(512, 20)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_y4r3f"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_kq0wk"]
+size = Vector2(128, 128)
 
 [node name="CaveLevel" type="Node2D"]
 
@@ -1156,8 +1165,30 @@ position = Vector2(-360, -8)
 [node name="SavePoint2" parent="Triggers" instance=ExtResource("18_apm6s")]
 position = Vector2(488, -840)
 
+[node name="AreaTitleTrigger" type="Area2D" parent="Triggers/SavePoint2"]
+collision_layer = 0
+collision_mask = 2
+monitorable = false
+script = ExtResource("36_y4r3f")
+AreaData = ExtResource("37_xdbyy")
+metadata/_custom_type_script = "uid://1okeb4x0c0oe"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Triggers/SavePoint2/AreaTitleTrigger"]
+shape = SubResource("RectangleShape2D_xdbyy")
+
 [node name="SavePoint3" parent="Triggers" instance=ExtResource("18_apm6s")]
 position = Vector2(2832, 536)
+
+[node name="AreaTitleTrigger" type="Area2D" parent="Triggers/SavePoint3"]
+collision_layer = 0
+collision_mask = 2
+monitorable = false
+script = ExtResource("36_y4r3f")
+AreaData = ExtResource("37_xdbyy")
+metadata/_custom_type_script = "uid://1okeb4x0c0oe"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Triggers/SavePoint3/AreaTitleTrigger"]
+shape = SubResource("RectangleShape2D_xdbyy")
 
 [node name="TutorialSign" parent="Triggers" instance=ExtResource("20_ikjip")]
 position = Vector2(-552, 48)
@@ -1207,6 +1238,32 @@ position = Vector2(-768, -320)
 
 [node name="BottomRight" type="Marker2D" parent="Triggers/ToCaveLevel/CameraBoundsTrigger"]
 position = Vector2(160, 288)
+
+[node name="AreaTitleTrigger" type="Area2D" parent="Triggers/ToCaveLevel"]
+collision_layer = 0
+collision_mask = 2
+monitorable = false
+script = ExtResource("36_y4r3f")
+AreaData = ExtResource("37_xdbyy")
+metadata/_custom_type_script = "uid://1okeb4x0c0oe"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Triggers/ToCaveLevel/AreaTitleTrigger"]
+shape = SubResource("RectangleShape2D_y4r3f")
+
+[node name="Entrance" type="Node2D" parent="Triggers"]
+
+[node name="AreaTitleTrigger" type="Area2D" parent="Triggers/Entrance"]
+position = Vector2(-464, 0)
+collision_layer = 0
+collision_mask = 2
+monitorable = false
+script = ExtResource("36_y4r3f")
+AreaData = ExtResource("37_xdbyy")
+metadata/_custom_type_script = "uid://1okeb4x0c0oe"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Triggers/Entrance/AreaTitleTrigger"]
+position = Vector2(56, -8)
+shape = SubResource("RectangleShape2D_kq0wk")
 
 [node name="Enemies" type="Node2D" parent="."]
 

--- a/Scenes/IceLevel.tscn
+++ b/Scenes/IceLevel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=4 uid="uid://08l80oe6062n"]
+[gd_scene load_steps=35 format=4 uid="uid://08l80oe6062n"]
 
 [ext_resource type="Texture2D" uid="uid://dqdm257r5iqny" path="res://Assets/Textures/ice-background.png" id="1_a6ife"]
 [ext_resource type="TileSet" uid="uid://dgouia3hp5uod" path="res://Assets/IceLevelTileset.tres" id="1_ictxf"]
@@ -16,6 +16,8 @@
 [ext_resource type="PackedScene" uid="uid://droah6sh8svm7" path="res://Entities/Enemies/EnemySpawner.tscn" id="8_l6ymw"]
 [ext_resource type="PackedScene" uid="uid://c4d5xqp3xrpxt" path="res://Environment/Triggers/Door.tscn" id="9_ictxf"]
 [ext_resource type="PackedScene" uid="uid://bpcek52j0ej41" path="res://Environment/Triggers/PermanentLever.tscn" id="10_ictxf"]
+[ext_resource type="Script" uid="uid://1okeb4x0c0oe" path="res://Environment/Triggers/AreaTitleTrigger.cs" id="10_va27l"]
+[ext_resource type="Resource" uid="uid://ccwojb7uocpof" path="res://Assets/AreaData/IceLevel.tres" id="11_va27l"]
 [ext_resource type="PackedScene" uid="uid://dnmh2cm2nk3d4" path="res://Saves/SavePoint.tscn" id="13_a6ife"]
 [ext_resource type="Script" uid="uid://cl675xn1flia5" path="res://Environment/Triggers/ActivationLogicActivator.cs" id="17_8siu1"]
 [ext_resource type="PackedScene" uid="uid://clprrlon6h18u" path="res://Entities/Enemies/IceBug/IceBug.tscn" id="19_nanud"]
@@ -68,6 +70,9 @@ size = Vector2(64, 64)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_60gh6"]
 size = Vector2(768, 64)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_84fhk"]
+size = Vector2(128, 128)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_jk61n"]
 size = Vector2(32, 72)
@@ -290,6 +295,17 @@ shape = SubResource("RectangleShape2D_5q37o")
 
 [node name="ToCave" type="Marker2D" parent="Triggers/ToCaveLevel/SceneTransitionTrigger" groups=["SceneMarkers"]]
 position = Vector2(56, 24)
+
+[node name="AreaTitleTrigger" type="Area2D" parent="Triggers/ToCaveLevel"]
+position = Vector2(888, 8)
+collision_layer = 0
+collision_mask = 2
+script = ExtResource("10_va27l")
+AreaData = ExtResource("11_va27l")
+metadata/_custom_type_script = "uid://1okeb4x0c0oe"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Triggers/ToCaveLevel/AreaTitleTrigger"]
+shape = SubResource("RectangleShape2D_84fhk")
 
 [node name="Platforms" type="Node2D" parent="."]
 

--- a/Scenes/IceLevel.tscn
+++ b/Scenes/IceLevel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=35 format=4 uid="uid://08l80oe6062n"]
+[gd_scene load_steps=36 format=4 uid="uid://08l80oe6062n"]
 
 [ext_resource type="Texture2D" uid="uid://dqdm257r5iqny" path="res://Assets/Textures/ice-background.png" id="1_a6ife"]
 [ext_resource type="TileSet" uid="uid://dgouia3hp5uod" path="res://Assets/IceLevelTileset.tres" id="1_ictxf"]
@@ -588,11 +588,41 @@ SaveKey = "ice/puzzle_1/lever"
 [node name="SavePoint" parent="Puzzles/Puzzle1" instance=ExtResource("13_a6ife")]
 position = Vector2(-352, 80)
 
+[node name="AreaTitleTrigger" type="Area2D" parent="Puzzles/Puzzle1/SavePoint"]
+collision_layer = 0
+collision_mask = 2
+script = ExtResource("10_va27l")
+AreaData = ExtResource("11_va27l")
+metadata/_custom_type_script = "uid://1okeb4x0c0oe"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Puzzles/Puzzle1/SavePoint/AreaTitleTrigger"]
+shape = SubResource("RectangleShape2D_84fhk")
+
 [node name="SavePoint2" parent="Puzzles/Puzzle1" instance=ExtResource("13_a6ife")]
 position = Vector2(1336, 120)
 
+[node name="AreaTitleTrigger" type="Area2D" parent="Puzzles/Puzzle1/SavePoint2"]
+collision_layer = 0
+collision_mask = 2
+script = ExtResource("10_va27l")
+AreaData = ExtResource("11_va27l")
+metadata/_custom_type_script = "uid://1okeb4x0c0oe"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Puzzles/Puzzle1/SavePoint2/AreaTitleTrigger"]
+shape = SubResource("RectangleShape2D_84fhk")
+
 [node name="SavePoint3" parent="Puzzles/Puzzle1" instance=ExtResource("13_a6ife")]
 position = Vector2(1368, -1816)
+
+[node name="AreaTitleTrigger" type="Area2D" parent="Puzzles/Puzzle1/SavePoint3"]
+collision_layer = 0
+collision_mask = 2
+script = ExtResource("10_va27l")
+AreaData = ExtResource("11_va27l")
+metadata/_custom_type_script = "uid://1okeb4x0c0oe"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Puzzles/Puzzle1/SavePoint3/AreaTitleTrigger"]
+shape = SubResource("RectangleShape2D_84fhk")
 
 [node name="Puzzle2" type="Node2D" parent="Puzzles"]
 position = Vector2(3136, -984)

--- a/UI/UIPlayerHud/AreaTitleCard.cs
+++ b/UI/UIPlayerHud/AreaTitleCard.cs
@@ -1,0 +1,103 @@
+using CrossedDimensions.Environment;
+using Godot;
+
+namespace CrossedDimensions.UI.UIPlayerHud;
+
+[GlobalClass]
+public partial class AreaTitleCard : Control
+{
+    [Export]
+    public Label TitleLabel { get; set; }
+
+    [Export]
+    public Label SubtitleLabel { get; set; }
+
+    [Export]
+    public AnimationPlayer AnimationPlayer { get; set; }
+
+    public int AnimationPlayCount { get; private set; }
+
+    private AreaData _lastShownAreaData;
+
+    public override void _Ready()
+    {
+        Visible = false;
+
+        if (AnimationPlayer is not null)
+        {
+            AnimationPlayer.AnimationFinished += OnAnimationFinished;
+        }
+
+        if (AreaManager.Instance is not null)
+        {
+            AreaManager.Instance.AreaTriggerEntered += OnAreaTriggerEntered;
+        }
+        else
+        {
+            GD.PushWarning("AreaTitleCard: AreaManager.Instance is null in _Ready.");
+        }
+    }
+
+    public override void _ExitTree()
+    {
+        if (AreaManager.Instance is not null)
+        {
+            AreaManager.Instance.AreaTriggerEntered -= OnAreaTriggerEntered;
+        }
+
+        if (AnimationPlayer is not null)
+        {
+            AnimationPlayer.AnimationFinished -= OnAnimationFinished;
+        }
+    }
+
+    private void OnAreaTriggerEntered(AreaData data)
+    {
+        if (data is null || IsSameArea(data, _lastShownAreaData))
+        {
+            return;
+        }
+
+        _lastShownAreaData = data;
+
+        if (TitleLabel is not null)
+        {
+            TitleLabel.Text = data.Title ?? "";
+        }
+
+        if (SubtitleLabel is not null)
+        {
+            SubtitleLabel.Text = data.Subtitle ?? "";
+            SubtitleLabel.Visible = !string.IsNullOrEmpty(SubtitleLabel.Text);
+        }
+
+        Show();
+        if (AnimationPlayer is not null)
+        {
+            AnimationPlayCount++;
+            AnimationPlayer.Play("display");
+        }
+    }
+    private void OnAnimationFinished(StringName animationName)
+    {
+        if (animationName == "display")
+        {
+            Hide();
+        }
+    }
+
+    private static bool IsSameArea(AreaData left, AreaData right)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        return left.Title == right.Title && left.Subtitle == right.Subtitle;
+    }
+}

--- a/UI/UIPlayerHud/AreaTitleCard.cs.uid
+++ b/UI/UIPlayerHud/AreaTitleCard.cs.uid
@@ -1,0 +1,1 @@
+uid://d3eys0flxrjua

--- a/UI/UIPlayerHud/AreaTitleCard.tscn
+++ b/UI/UIPlayerHud/AreaTitleCard.tscn
@@ -3,59 +3,6 @@
 [ext_resource type="Script" uid="uid://d3eys0flxrjua" path="res://UI/UIPlayerHud/AreaTitleCard.cs" id="1_script"]
 [ext_resource type="Theme" uid="uid://b5cn5pegvkqek" path="res://Assets/UITheme.tres" id="2_theme"]
 
-[sub_resource type="Animation" id="Animation_display"]
-resource_name = "display"
-length = 4.0000124
-step = 0.125
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("PanelContainer:modulate")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.25, 3.5, 4),
-"transitions": PackedFloat32Array(1, 1, 1, 1),
-"update": 0,
-"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("PanelContainer/MarginContainer/VBoxContainer/Title:visible_ratio")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(),
-"transitions": PackedFloat32Array(),
-"update": 0,
-"values": []
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("PanelContainer/MarginContainer/VBoxContainer/Subtitle:visible_ratio")
-tracks/2/interp = 1
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(1, 2),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [0.0, 1.0]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("PanelContainer:position")
-tracks/3/interp = 1
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0, 0.5),
-"transitions": PackedFloat32Array(0.25, 1),
-"update": 0,
-"values": [Vector2(-16, 258), Vector2(0, 258)]
-}
-
 [sub_resource type="Animation" id="Animation_pw45v"]
 length = 0.001
 tracks/0/type = "value"
@@ -68,7 +15,7 @@ tracks/0/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [0.0]
+"values": [1.0]
 }
 tracks/1/type = "value"
 tracks/1/imported = false
@@ -81,6 +28,59 @@ tracks/1/keys = {
 "transitions": PackedFloat32Array(1),
 "update": 0,
 "values": [Vector2(0, 290)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("PanelContainer:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_display"]
+resource_name = "display"
+length = 8.000012
+step = 0.125
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("PanelContainer:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.25, 6, 8),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("PanelContainer/MarginContainer/VBoxContainer/Subtitle:visible_ratio")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(1, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 1.0]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("PanelContainer:position")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(0.25, 1),
+"update": 0,
+"values": [Vector2(-16, 258), Vector2(0, 258)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_area_title"]
@@ -153,5 +153,3 @@ color = Color(1, 0.6276082, 0.50818264, 1)
 modulate = Color(1, 1, 1, 0.49803922)
 layout_mode = 2
 text = "Area Subtitle"
-visible_characters = 0
-visible_ratio = 0.0

--- a/UI/UIPlayerHud/AreaTitleCard.tscn
+++ b/UI/UIPlayerHud/AreaTitleCard.tscn
@@ -1,0 +1,157 @@
+[gd_scene load_steps=7 format=3 uid="uid://bpis6alqp6fal"]
+
+[ext_resource type="Script" uid="uid://d3eys0flxrjua" path="res://UI/UIPlayerHud/AreaTitleCard.cs" id="1_script"]
+[ext_resource type="Theme" uid="uid://b5cn5pegvkqek" path="res://Assets/UITheme.tres" id="2_theme"]
+
+[sub_resource type="Animation" id="Animation_display"]
+resource_name = "display"
+length = 4.0000124
+step = 0.125
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("PanelContainer:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.25, 3.5, 4),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("PanelContainer/MarginContainer/VBoxContainer/Title:visible_ratio")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(),
+"transitions": PackedFloat32Array(),
+"update": 0,
+"values": []
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("PanelContainer/MarginContainer/VBoxContainer/Subtitle:visible_ratio")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(1, 2),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 1.0]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("PanelContainer:position")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(0.25, 1),
+"update": 0,
+"values": [Vector2(-16, 258), Vector2(0, 258)]
+}
+
+[sub_resource type="Animation" id="Animation_pw45v"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("PanelContainer/MarginContainer/VBoxContainer/Subtitle:visible_ratio")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("PanelContainer:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector2(0, 290)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_area_title"]
+_data = {
+&"RESET": SubResource("Animation_pw45v"),
+&"display": SubResource("Animation_display")
+}
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_pw45v"]
+content_margin_left = 16.0
+content_margin_top = 16.0
+content_margin_right = 16.0
+content_margin_bottom = 16.0
+
+[node name="AreaTitleCard" type="Control" node_paths=PackedStringArray("TitleLabel", "SubtitleLabel", "AnimationPlayer")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme = ExtResource("2_theme")
+script = ExtResource("1_script")
+TitleLabel = NodePath("PanelContainer/MarginContainer/VBoxContainer/Title")
+SubtitleLabel = NodePath("PanelContainer/MarginContainer/VBoxContainer/Subtitle")
+AnimationPlayer = NodePath("AnimationPlayer")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+&"": SubResource("AnimationLibrary_area_title")
+}
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -70.0
+offset_right = 184.0
+offset_bottom = 32.0
+grow_vertical = 0
+theme_override_styles/panel = SubResource("StyleBoxEmpty_pw45v")
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 14
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 14
+theme_override_constants/margin_bottom = 10
+
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 2
+
+[node name="Title" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 30
+text = "Area Title"
+
+[node name="ColorRect" type="ColorRect" parent="PanelContainer/MarginContainer/VBoxContainer/Title"]
+layout_mode = 1
+offset_left = -12.0
+offset_top = -2.0
+offset_right = -10.0
+offset_bottom = 28.0
+color = Color(1, 0.6276082, 0.50818264, 1)
+
+[node name="Subtitle" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
+modulate = Color(1, 1, 1, 0.49803922)
+layout_mode = 2
+text = "Area Subtitle"
+visible_characters = 0
+visible_ratio = 0.0

--- a/UI/UIPlayerHud/PlayerHud.tscn
+++ b/UI/UIPlayerHud/PlayerHud.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Script" uid="uid://ctc2mwgudlrdc" path="res://UI/UIPlayerHud/player_hud.gd" id="1_ojyrw"]
 [ext_resource type="PackedScene" uid="uid://c3x3w5b4ecvp6" path="res://UI/UIDialogueBox/DialogueBox.tscn" id="3_cgrjy"]
 [ext_resource type="PackedScene" path="res://UI/UIPlayerHud/CloneOffscreenIndicator.tscn" id="4_clone_indicator"]
+[ext_resource type="PackedScene" path="res://UI/UIPlayerHud/AreaTitleCard.tscn" id="4_area_title"]
 
 [node name="PlayerHud" type="Control"]
 layout_mode = 3
@@ -23,4 +24,7 @@ offset_top = -96.0
 offset_bottom = -24.0
 
 [node name="CloneOffscreenIndicator" parent="." instance=ExtResource("4_clone_indicator")]
+layout_mode = 1
+
+[node name="AreaTitleCard" parent="." instance=ExtResource("4_area_title")]
 layout_mode = 1

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ DebugHUD="*res://Debug/DebugHud.tscn"
 MusicManager="*res://Audio/MusicManager.cs"
 SaveManager="*res://Saves/SaveManager.cs"
 SceneManager="*res://Saves/SceneManager.cs"
+AreaManager="*res://Environment/AreaManager.cs"
 
 [display]
 


### PR DESCRIPTION
Adds area title cards to the bottom left of the screen. Closes #95 

---

This pull request introduces a new Area Title system that displays the current area name and subtitle to the player when they enter specific regions in a level. The implementation includes new data/resource types, triggers, a manager, a UI component, and comprehensive tests. These changes also integrate the system into the `CaveLevel` and `IceLevel` scenes.

**New Area Title System:**

* Added `AreaData` resource for storing area titles and subtitles.
* Implemented `AreaManager` singleton to manage area title signals.
* Created `AreaTitleTrigger` for emitting signals when the player enters an area.
* Developed `AreaTitleCard` UI component to display area information and handle animation logic.

**Scene Integration:**

* Integrated `AreaTitleTrigger` and `AreaData` into `CaveLevel.tscn` and `IceLevel.tscn`, including appropriate nodes and resources. [[1]](diffhunk://#diff-011fdfc253b7cd2543273661b7e56997c3fc1ac7dd30dda70639e62409542d66R42-R43) [[2]](diffhunk://#diff-011fdfc253b7cd2543273661b7e56997c3fc1ac7dd30dda70639e62409542d66R140-R145) [[3]](diffhunk://#diff-011fdfc253b7cd2543273661b7e56997c3fc1ac7dd30dda70639e62409542d66R1201-R1207) [[4]](diffhunk://#diff-30397df886225a03240c6329be0b324e47f4f45dcce3be347e34b9caef3b69fcR19-R20) [[5]](diffhunk://#diff-30397df886225a03240c6329be0b324e47f4f45dcce3be347e34b9caef3b69fcR61-R69) [[6]](diffhunk://#diff-30397df886225a03240c6329be0b324e47f4f45dcce3be347e34b9caef3b69fcR297-R306)

**Testing:**

* Added unit and integration tests for the area title system, covering signal emission, UI updates, and animation behavior. [[1]](diffhunk://#diff-bdf6dd47c9e6088b4a2cafa1b3514ad6c14e511d495f2ed88a36f0487b1bc395R1-R35) [[2]](diffhunk://#diff-5b8209fcda42b34f0705f92eddd8ec6f1ebca845c61a56a3ad21cae7098e7465R1-R189)