### PR TITLE
feature: Add off-screen indicator

### DIFF
--- a/UI/UIPlayerHud/CloneOffscreenIndicator.cs
+++ b/UI/UIPlayerHud/CloneOffscreenIndicator.cs
@@ -1,0 +1,135 @@
+using Godot;
+using Characters = CrossedDimensions.Characters;
+
+namespace CrossedDimensions.UI;
+
+[GlobalClass]
+public partial class CloneOffscreenIndicator : Control
+{
+    [Export]
+    public float EdgePadding { get; set; } = 12f;
+
+    [Export]
+    public Color IndicatorColor { get; set; } = new(0.753f, 0.502f, 1f);
+
+    [Export]
+    public float PulseFrequency { get; set; } = 2f;
+
+    [Export]
+    public bool SnapToPixel { get; set; } = true;
+
+    private Characters.Character _clone;
+    private float _pulseTime;
+
+    public void SetClone(Characters.Character clone)
+    {
+        _clone = clone;
+        Visible = true;
+    }
+
+    public void ClearClone()
+    {
+        _clone = null;
+        Visible = false;
+    }
+
+    public override void _Process(double delta)
+    {
+        if (_clone is null || !IsInstanceValid(_clone))
+        {
+            Visible = false;
+            _pulseTime = 0f;
+            return;
+        }
+
+        Transform2D canvasXform = GetViewport().GetCanvasTransform();
+        Vector2 screenPos = canvasXform * _clone.GlobalPosition;
+        Vector2 screenSize = GetViewportRect().Size;
+
+        var screenRect = new Rect2(Vector2.Zero, screenSize);
+        if (screenRect.HasPoint(screenPos))
+        {
+            Visible = false;
+            _pulseTime = 0f;
+            return;
+        }
+
+        Vector2 center = screenSize * 0.5f;
+        Vector2 dir = (screenPos - center).Normalized();
+
+        float tMin = float.PositiveInfinity;
+
+        if (!Mathf.IsZeroApprox(dir.X))
+        {
+            float tLeft = (0f - center.X) / dir.X;
+            if (tLeft > 0f)
+            {
+                tMin = Mathf.Min(tMin, tLeft);
+            }
+
+            float tRight = (screenSize.X - center.X) / dir.X;
+            if (tRight > 0f)
+            {
+                tMin = Mathf.Min(tMin, tRight);
+            }
+        }
+
+        if (!Mathf.IsZeroApprox(dir.Y))
+        {
+            float tTop = (0f - center.Y) / dir.Y;
+            if (tTop > 0f)
+            {
+                tMin = Mathf.Min(tMin, tTop);
+            }
+
+            float tBottom = (screenSize.Y - center.Y) / dir.Y;
+            if (tBottom > 0f)
+            {
+                tMin = Mathf.Min(tMin, tBottom);
+            }
+        }
+
+        Vector2 edgePoint = float.IsPositiveInfinity(tMin)
+            ? screenPos
+            : center + dir * tMin;
+
+        float clampedPadding = Mathf.Max(0f, EdgePadding);
+        Vector2 paddedSize = new(
+            Mathf.Max(0f, screenSize.X - clampedPadding * 2f),
+            Mathf.Max(0f, screenSize.Y - clampedPadding * 2f));
+        var paddedRect = new Rect2(new Vector2(clampedPadding, clampedPadding), paddedSize);
+
+        Position = paddedRect.HasArea()
+            ? edgePoint.Clamp(paddedRect.Position, paddedRect.End)
+            : edgePoint;
+
+        if (SnapToPixel)
+        {
+            Position = Position.Round();
+        }
+
+        Rotation = (screenPos - Position).Angle();
+        _pulseTime += (float)delta;
+        Visible = true;
+        QueueRedraw();
+    }
+
+    public override void _Draw()
+    {
+        float blend = 0.5f + 0.5f * Mathf.Sin(_pulseTime * Mathf.Tau * PulseFrequency);
+        Color animatedColor = IndicatorColor.Lerp(new Color(1f, 1f, 1f, IndicatorColor.A), blend);
+
+        Color backColor = animatedColor;
+        backColor.A = 0.5f;
+
+        DrawPolygon(
+            new Vector2[] { new(-6f, -5f), new(0f, 0f), new(-6f, 5f) },
+            new Color[] { backColor, backColor, backColor });
+
+        DrawPolygon(
+            new Vector2[] { new(-1f, -5f), new(5f, 0f), new(-1f, 5f) },
+            new Color[] { animatedColor, animatedColor, animatedColor });
+
+        DrawCircle(new Vector2(-13f, 0f), 3f, animatedColor);
+    }
+}

--- a/UI/UIPlayerHud/CloneOffscreenIndicator.cs.uid
+++ b/UI/UIPlayerHud/CloneOffscreenIndicator.cs.uid
@@ -1,0 +1,1 @@
+uid://ckp0ljeisauhl

--- a/UI/UIPlayerHud/CloneOffscreenIndicator.tscn
+++ b/UI/UIPlayerHud/CloneOffscreenIndicator.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://UI/UIPlayerHud/CloneOffscreenIndicator.cs" id="1_clone_indicator"]
+
+[node name="CloneOffscreenIndicator" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+visible = false
+script = ExtResource("1_clone_indicator")

--- a/UI/UIPlayerHud/PlayerHud.tscn
+++ b/UI/UIPlayerHud/PlayerHud.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://c0m8rgcsh18sw"]
+[gd_scene load_steps=5 format=3 uid="uid://c0m8rgcsh18sw"]
 
 [ext_resource type="PackedScene" uid="uid://dmb84h028q1aa" path="res://UI/UIPlayerHud/HealthBars.tscn" id="1_1rgaj"]
 [ext_resource type="Script" uid="uid://ctc2mwgudlrdc" path="res://UI/UIPlayerHud/player_hud.gd" id="1_ojyrw"]
 [ext_resource type="PackedScene" uid="uid://c3x3w5b4ecvp6" path="res://UI/UIDialogueBox/DialogueBox.tscn" id="3_cgrjy"]
+[ext_resource type="PackedScene" path="res://UI/UIPlayerHud/CloneOffscreenIndicator.tscn" id="4_clone_indicator"]
 
 [node name="PlayerHud" type="Control"]
 layout_mode = 3
@@ -20,3 +21,6 @@ layout_mode = 1
 layout_mode = 1
 offset_top = -96.0
 offset_bottom = -24.0
+
+[node name="CloneOffscreenIndicator" parent="." instance=ExtResource("4_clone_indicator")]
+layout_mode = 1

--- a/UI/UIPlayerHud/player_hud.gd
+++ b/UI/UIPlayerHud/player_hud.gd
@@ -2,6 +2,7 @@ extends Node
 #creates health_bar variable of type HealthBar and assigns it the value
 #of the HealthBars Node when the PlayerHud Node gets added to the scean tree. 
 @onready var health_bars: HealthBars = $HealthBars
+@onready var clone_indicator: CloneOffscreenIndicator = $CloneOffscreenIndicator
 #creates characer varable of type Character, which is a class. @export 
 # allows godot to define the object instance of character at runtime
 @export var character: Character 
@@ -50,6 +51,7 @@ func _on_character_split(_orig_character, clone_character: Character):
 	health_bars.clone_health_bar.show_health_bar()
 	health_bars.heal_pool_bar.max_value = character.Health.MaxHealth
 	health_bars.heal_pool_bar.value = character.Cloneable.HealingPool
+	clone_indicator.SetClone(clone_character)
 
 
 
@@ -58,6 +60,7 @@ func _on_character_merge(_orig_character: Character):
 	health_bars.main_health_bar.set_health_bar_full(character.Health.MaxHealth)
 	health_bars.clone_health_bar.hide_health_bar()
 	_on_main_health_changed(1) #ensures the most upto date health value is shown.
+	clone_indicator.ClearClone()
 
 func _on_healing_pool_changed(current: float, max: float) -> void:
 	health_bars.heal_pool_bar.max_value = max


### PR DESCRIPTION
Adds an offscreen arrow to show where the clone is should it move out of the camera view. Closes #130 

---

This pull request introduces a new offscreen indicator UI element that visually points to the player's clone when it is offscreen. The main changes include the implementation of the `CloneOffscreenIndicator` control, its integration into the player HUD scene, and the necessary updates to the HUD script to show and hide the indicator as the clone is created or merged.

**New Offscreen Indicator Feature:**

* Added a new `CloneOffscreenIndicator` control (`CloneOffscreenIndicator.cs`) that calculates the direction and draws a pulsing arrow at the screen edge pointing towards the offscreen clone.
* Created a scene file for the indicator (`CloneOffscreenIndicator.tscn`) and registered its unique identifier (`CloneOffscreenIndicator.cs.uid`). [[1]](diffhunk://#diff-63d5a4b1d313e1b4e14ffe47e38031afd347cb36569a3b67fc150250fa34d100R1-R14) [[2]](diffhunk://#diff-b9bf6ea99afafd25daf56634653f7bce20cf329b19487dc91a69988f1ff20bb5R1)

**Integration with Player HUD:**

* Added the `CloneOffscreenIndicator` as a child node in the `PlayerHud` scene and loaded its scene resource. [[1]](diffhunk://#diff-d832688f26e33a7edc5f561fe691428f28b823df35f5b471286758ef4b97a03eL1-R6) [[2]](diffhunk://#diff-d832688f26e33a7edc5f561fe691428f28b823df35f5b471286758ef4b97a03eR24-R26)
* Updated the `player_hud.gd` script to reference the indicator and to call its `SetClone` and `ClearClone` methods when the clone is created or merged, ensuring the indicator appears and disappears at the correct times. [[1]](diffhunk://#diff-4c0e43488b9e2e5bf1e5106f8dce02de431e5bd9b6330b40e23ffbac009ef587R5) [[2]](diffhunk://#diff-4c0e43488b9e2e5bf1e5106f8dce02de431e5bd9b6330b40e23ffbac009ef587R54) [[3]](diffhunk://#diff-4c0e43488b9e2e5bf1e5106f8dce02de431e5bd9b6330b40e23ffbac009ef587R63)