### PR TITLE
refactor: Extract player and clone scene management

### DIFF
--- a/Characters/BaseCharacter.tscn
+++ b/Characters/BaseCharacter.tscn
@@ -1,0 +1,185 @@
+[gd_scene load_steps=25 format=3 uid="uid://dbrsyvtefql5h"]
+
+[ext_resource type="Script" uid="uid://t5xa8pqv2chw" path="res://Characters/Character.cs" id="1_xloa1"]
+[ext_resource type="Script" uid="uid://dqpkcaajawmmr" path="res://Characters/CloneableComponent.cs" id="2_peemv"]
+[ext_resource type="Script" uid="uid://cnt6dnn0xqp5j" path="res://States/StateMachine.cs" id="3_677pu"]
+[ext_resource type="PackedScene" uid="uid://cx05fuu7ep1mn" path="res://Components/FreezableComponent.tscn" id="4_a4a8l"]
+[ext_resource type="Script" uid="uid://c25jh47h6bqj2" path="res://States/Characters/CharacterIdleState.cs" id="4_peemv"]
+[ext_resource type="Script" uid="uid://cgtxr8m2no0u6" path="res://Components/InventoryComponent.cs" id="4_vvdcd"]
+[ext_resource type="PackedScene" uid="uid://d31qgr0s5tloa" path="res://Items/PelletShooter.tscn" id="5_gxkbl"]
+[ext_resource type="Script" uid="uid://wjso6aicxr3t" path="res://Characters/Controllers/UserController.cs" id="5_vdqda"]
+[ext_resource type="Script" uid="uid://ca34tm7a0qjwx" path="res://States/Characters/CharacterMoveState.cs" id="5_xloa1"]
+[ext_resource type="Script" uid="uid://dseku1fko6r7x" path="res://States/Characters/CharacterAirState.cs" id="6_4b18b"]
+[ext_resource type="Script" uid="uid://3gwoekpmt5om" path="res://States/Characters/CharacterSplitState.cs" id="8_omicx"]
+[ext_resource type="Script" uid="uid://cnuet38ohgvae" path="res://States/Characters/CharacterMergeHoldState.cs" id="9_mergehold"]
+[ext_resource type="Script" uid="uid://bks6bqyscxh45" path="res://Components/HealthComponent.cs" id="11_fgiha"]
+[ext_resource type="Script" uid="uid://u7a6ad2ljwu6" path="res://BoundingBoxes/Hurtbox.cs" id="11_p3cti"]
+[ext_resource type="Script" uid="uid://duuxf7bmm26wh" path="res://States/Weapons/Behaviors/PlaySoundBehavior.cs" id="12_14sst"]
+[ext_resource type="Script" uid="uid://3vhttrda1lbc" path="res://Characters/DamageEffectSource.cs" id="13_source"]
+[ext_resource type="Texture2D" uid="uid://dr1ss6b1in635" path="res://Assets/Textures/Player/shale-neutral.png" id="15_5ocvt"]
+[ext_resource type="Texture2D" uid="uid://d02ajcqv81keo" path="res://Assets/Textures/Player/shale-arm.png" id="16_5ocvt"]
+[ext_resource type="Script" uid="uid://cn1vv5mqclgbe" path="res://Characters/PlayerAnimator.cs" id="17_pv7kk"]
+[ext_resource type="Script" uid="uid://c0wdfrdxqj7dx" path="res://States/Characters/CharacterNoclipState.cs" id="18_noclip"]
+[ext_resource type="AudioStream" uid="uid://bsuu6fafv5qx4" path="res://Assets/Sounds/dash.tres" id="23_ss146"]
+[ext_resource type="AudioStream" uid="uid://ctrrvnkhdjyph" path="res://Assets/Sounds/damage.wav" id="25_cgsnx"]
+[ext_resource type="AudioStream" uid="uid://cm8l7obm2sri2" path="res://Assets/Sounds/446010__slavicmagic__backwards-whoosh.wav" id="6_tkj71"]
+[ext_resource type="Script" uid="uid://ora76n6m6rkk" path="res://States/Characters/Behaviors/DashGhostTrailBehavior.cs" id="29_dashghost"]
+[ext_resource type="Shader" uid="uid://b4vi0d65lav86" path="res://Shaders/GhostDash.gdshader" id="30_ghostshader"]
+[ext_resource type="Script" uid="uid://g3ryl11hyvb5" path="res://Characters/MergeEffectSource.cs" id="31_mergeeffect"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_xloa1"]
+size = Vector2(16, 24)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_fgiha"]
+size = Vector2(4, 8)
+
+[node name="Character" type="CharacterBody2D" node_paths=PackedStringArray("SpriteAnchor", "Controller", "MovementStateMachine", "Inventory", "Freezable", "Health", "Cloneable") groups=["Player"]]
+collision_layer = 2
+collision_mask = 29
+script = ExtResource("1_xloa1")
+SpriteAnchor = NodePath("SpriteAnchor")
+Controller = NodePath("ControllerComponent")
+MovementStateMachine = NodePath("MovementStateMachine")
+Inventory = NodePath("InventoryComponent")
+Freezable = NodePath("FreezableComponent")
+Health = NodePath("HealthComponent")
+Cloneable = NodePath("CloneableComponent")
+
+[node name="ControllerComponent" type="Node2D" parent="."]
+unique_name_in_owner = true
+script = ExtResource("5_vdqda")
+
+[node name="CloneableComponent" type="Node" parent="."]
+unique_name_in_owner = true
+script = ExtResource("2_peemv")
+
+[node name="MergeEffectSource" type="Node" parent="CloneableComponent" node_paths=PackedStringArray("Cloneable", "OriginalSpriteAnchor", "MergeSound")]
+script = ExtResource("31_mergeeffect")
+Cloneable = NodePath("..")
+OriginalSpriteAnchor = NodePath("../../SpriteAnchor")
+GhostShader = ExtResource("30_ghostshader")
+GhostColor = Color(0.921569, 0.203922, 0.607843, 1)
+MergeSound = NodePath("AudioStreamPlayer2D")
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="CloneableComponent/MergeEffectSource"]
+stream = ExtResource("6_tkj71")
+
+[node name="FreezableComponent" parent="." instance=ExtResource("4_a4a8l")]
+
+[node name="InventoryComponent" type="Node2D" parent="." node_paths=PackedStringArray("OwnerCharacter")]
+script = ExtResource("4_vvdcd")
+OwnerCharacter = NodePath("..")
+metadata/_custom_type_script = "uid://cgtxr8m2no0u6"
+
+[node name="PelletShooter" parent="InventoryComponent" instance=ExtResource("5_gxkbl")]
+
+[node name="MovementStateMachine" type="Node" parent="." node_paths=PackedStringArray("InitialState")]
+script = ExtResource("3_677pu")
+InitialState = NodePath("Idle State")
+metadata/_custom_type_script = "uid://cnt6dnn0xqp5j"
+
+[node name="Idle State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("MoveState", "AirState", "MergeHoldState", "SplitState")]
+script = ExtResource("4_peemv")
+MoveState = NodePath("../Move State")
+AirState = NodePath("../Air State")
+MergeHoldState = NodePath("../Merge Hold State")
+SplitState = NodePath("../Split State")
+
+[node name="Move State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("IdleState", "AirState", "SplitState", "MergeHoldState")]
+script = ExtResource("5_xloa1")
+IdleState = NodePath("../Idle State")
+AirState = NodePath("../Air State")
+SplitState = NodePath("../Split State")
+MergeHoldState = NodePath("../Merge Hold State")
+
+[node name="Air State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("IdleState", "SplitState", "MergeHoldState")]
+script = ExtResource("6_4b18b")
+IdleState = NodePath("../Idle State")
+SplitState = NodePath("../Split State")
+MergeHoldState = NodePath("../Merge Hold State")
+
+[node name="Split State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("IdleState")]
+script = ExtResource("8_omicx")
+IdleState = NodePath("../Idle State")
+
+[node name="PlaySoundBehavior" type="Node" parent="MovementStateMachine/Split State" node_paths=PackedStringArray("Sound")]
+script = ExtResource("12_14sst")
+Sound = NodePath("../../../Sounds/Dash")
+metadata/_custom_type_script = "uid://duuxf7bmm26wh"
+
+[node name="DashGhostTrailBehavior" type="Node" parent="MovementStateMachine/Split State" node_paths=PackedStringArray("SpriteAnchor")]
+script = ExtResource("29_dashghost")
+SpriteAnchor = NodePath("../../../SpriteAnchor")
+GhostShader = ExtResource("30_ghostshader")
+GhostColor = Color(0.92156863, 0.20392157, 0.60784316, 0.49803922)
+GhostLifetime = 0.25
+
+[node name="Merge Hold State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("IdleState")]
+script = ExtResource("9_mergehold")
+IdleState = NodePath("../Idle State")
+
+[node name="Noclip State" type="Node" parent="MovementStateMachine"]
+script = ExtResource("18_noclip")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, -5)
+shape = SubResource("RectangleShape2D_xloa1")
+
+[node name="HealthComponent" type="Node" parent="."]
+script = ExtResource("11_fgiha")
+MaxHealth = 100
+CurrentHealth = 100
+
+[node name="DamageEffectSource" type="Node" parent="HealthComponent" node_paths=PackedStringArray("DamageSound", "Health", "SpriteAnchor", "Character")]
+script = ExtResource("13_source")
+DamageSound = NodePath("../../Sounds/Hurt")
+Health = NodePath("..")
+SpriteAnchor = NodePath("../../SpriteAnchor")
+Character = NodePath("../..")
+DamageToIntensity = 0.4
+MinimumIntensity = 0.25
+SpriteHighlightGain = 1.5
+
+[node name="Hurtbox" type="Area2D" parent="." node_paths=PackedStringArray("HealthComponent", "OwnerCharacter")]
+position = Vector2(0, -5)
+collision_layer = 256
+collision_mask = 512
+script = ExtResource("11_p3cti")
+HealthComponent = NodePath("../HealthComponent")
+OwnerCharacter = NodePath("..")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Hurtbox"]
+shape = SubResource("RectangleShape2D_fgiha")
+
+[node name="SpriteAnchor" type="Node2D" parent="."]
+
+[node name="Sprite2D" type="Sprite2D" parent="SpriteAnchor"]
+texture_filter = 1
+position = Vector2(0, -8)
+scale = Vector2(0.125, 0.125)
+texture = ExtResource("15_5ocvt")
+
+[node name="ArmAnchor" type="Node2D" parent="SpriteAnchor"]
+position = Vector2(-3, -7)
+
+[node name="Sprite2D" type="Sprite2D" parent="SpriteAnchor/ArmAnchor"]
+scale = Vector2(0.125, 0.125)
+texture = ExtResource("16_5ocvt")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="." node_paths=PackedStringArray("PlayerCharacter", "BodyAnchor", "ArmAnchor")]
+script = ExtResource("17_pv7kk")
+PlayerCharacter = NodePath("..")
+BodyAnchor = NodePath("../SpriteAnchor")
+ArmAnchor = NodePath("../SpriteAnchor/ArmAnchor")
+
+[node name="Sounds" type="Node2D" parent="."]
+
+[node name="Dash" type="AudioStreamPlayer2D" parent="Sounds"]
+stream = ExtResource("23_ss146")
+volume_db = -5.0
+bus = &"SFX"
+
+[node name="Hurt" type="AudioStreamPlayer2D" parent="Sounds"]
+stream = ExtResource("25_cgsnx")
+volume_db = 3.0
+bus = &"SFX"

--- a/Characters/Character.tscn
+++ b/Characters/Character.tscn
@@ -1,182 +1,34 @@
-[gd_scene load_steps=32 format=3 uid="uid://cjo8oxurlpsup"]
+[gd_scene load_steps=6 format=3 uid="uid://cjo8oxurlpsup"]
 
-[ext_resource type="Script" uid="uid://t5xa8pqv2chw" path="res://Characters/Character.cs" id="1_xloa1"]
-[ext_resource type="Script" uid="uid://dqpkcaajawmmr" path="res://Characters/CloneableComponent.cs" id="2_peemv"]
-[ext_resource type="Script" uid="uid://cnt6dnn0xqp5j" path="res://States/StateMachine.cs" id="3_677pu"]
-[ext_resource type="PackedScene" uid="uid://cx05fuu7ep1mn" path="res://Components/FreezableComponent.tscn" id="4_a4a8l"]
-[ext_resource type="Script" uid="uid://c25jh47h6bqj2" path="res://States/Characters/CharacterIdleState.cs" id="4_peemv"]
-[ext_resource type="Script" uid="uid://cgtxr8m2no0u6" path="res://Components/InventoryComponent.cs" id="4_vvdcd"]
-[ext_resource type="PackedScene" uid="uid://d31qgr0s5tloa" path="res://Items/PelletShooter.tscn" id="5_gxkbl"]
-[ext_resource type="Script" uid="uid://wjso6aicxr3t" path="res://Characters/Controllers/UserController.cs" id="5_vdqda"]
-[ext_resource type="Script" uid="uid://ca34tm7a0qjwx" path="res://States/Characters/CharacterMoveState.cs" id="5_xloa1"]
-[ext_resource type="Script" uid="uid://dseku1fko6r7x" path="res://States/Characters/CharacterAirState.cs" id="6_4b18b"]
-[ext_resource type="AudioStream" uid="uid://cm8l7obm2sri2" path="res://Assets/Sounds/446010__slavicmagic__backwards-whoosh.wav" id="6_tkj71"]
-[ext_resource type="Script" uid="uid://3gwoekpmt5om" path="res://States/Characters/CharacterSplitState.cs" id="8_omicx"]
-[ext_resource type="Script" uid="uid://cnuet38ohgvae" path="res://States/Characters/CharacterMergeHoldState.cs" id="9_mergehold"]
-[ext_resource type="Script" uid="uid://bks6bqyscxh45" path="res://Components/HealthComponent.cs" id="11_fgiha"]
-[ext_resource type="Script" uid="uid://u7a6ad2ljwu6" path="res://BoundingBoxes/Hurtbox.cs" id="11_p3cti"]
-[ext_resource type="Script" uid="uid://duuxf7bmm26wh" path="res://States/Weapons/Behaviors/PlaySoundBehavior.cs" id="12_14sst"]
-[ext_resource type="Script" uid="uid://2eq4bkx445ky" path="res://Characters/PlayerDeathHandler.cs" id="12_pv7kk"]
-[ext_resource type="Script" uid="uid://3vhttrda1lbc" path="res://Characters/DamageEffectSource.cs" id="13_source"]
-[ext_resource type="PackedScene" uid="uid://c0m8rgcsh18sw" path="res://UI/UIPlayerHud/PlayerHud.tscn" id="14_fgvlp"]
-[ext_resource type="Texture2D" uid="uid://dr1ss6b1in635" path="res://Assets/Textures/Player/shale-neutral.png" id="15_5ocvt"]
-[ext_resource type="PackedScene" uid="uid://diyetqkjfxg45" path="res://UI/UIPauseMenu/PauseMenu.tscn" id="15_gxkbl"]
-[ext_resource type="Texture2D" uid="uid://d02ajcqv81keo" path="res://Assets/Textures/Player/shale-arm.png" id="16_5ocvt"]
-[ext_resource type="Script" uid="uid://cn1vv5mqclgbe" path="res://Characters/PlayerAnimator.cs" id="17_pv7kk"]
-[ext_resource type="Script" uid="uid://c0wdfrdxqj7dx" path="res://States/Characters/CharacterNoclipState.cs" id="18_noclip"]
-[ext_resource type="Script" uid="uid://csw8t885g1wbu" path="res://States/Characters/CameraShiftBehavior.cs" id="19_camshift"]
-[ext_resource type="AudioStream" uid="uid://bsuu6fafv5qx4" path="res://Assets/Sounds/dash.tres" id="23_ss146"]
-[ext_resource type="AudioStream" uid="uid://ctrrvnkhdjyph" path="res://Assets/Sounds/damage.wav" id="25_cgsnx"]
-[ext_resource type="Script" uid="uid://ora76n6m6rkk" path="res://States/Characters/Behaviors/DashGhostTrailBehavior.cs" id="29_dashghost"]
-[ext_resource type="Shader" uid="uid://b4vi0d65lav86" path="res://Shaders/GhostDash.gdshader" id="30_ghostshader"]
-[ext_resource type="Script" uid="uid://g3ryl11hyvb5" path="res://Characters/MergeEffectSource.cs" id="31_mergeeffect"]
+[ext_resource type="PackedScene" uid="uid://dbrsyvtefql5h" path="res://Characters/BaseCharacter.tscn" id="1_base"]
+[ext_resource type="Script" uid="uid://2eq4bkx445ky" path="res://Characters/PlayerDeathHandler.cs" id="2_death"]
+[ext_resource type="PackedScene" uid="uid://c0m8rgcsh18sw" path="res://UI/UIPlayerHud/PlayerHud.tscn" id="3_hud"]
+[ext_resource type="PackedScene" uid="uid://diyetqkjfxg45" path="res://UI/UIPauseMenu/PauseMenu.tscn" id="4_pause"]
+[ext_resource type="Script" uid="uid://csw8t885g1wbu" path="res://States/Characters/CameraShiftBehavior.cs" id="5_camshift"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_xloa1"]
-size = Vector2(16, 24)
+[node name="Character" instance=ExtResource("1_base")]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_fgiha"]
-size = Vector2(4, 8)
-
-[node name="Character" type="CharacterBody2D" node_paths=PackedStringArray("SpriteAnchor", "Controller", "MovementStateMachine", "Inventory", "Freezable", "Health", "Cloneable") groups=["Player"]]
-collision_layer = 2
-collision_mask = 29
-script = ExtResource("1_xloa1")
-SpriteAnchor = NodePath("SpriteAnchor")
-Controller = NodePath("ControllerComponent")
-MovementStateMachine = NodePath("MovementStateMachine")
-Inventory = NodePath("InventoryComponent")
-Freezable = NodePath("FreezableComponent")
-Health = NodePath("HealthComponent")
-Cloneable = NodePath("CloneableComponent")
-
-[node name="ControllerComponent" type="Node2D" parent="."]
-unique_name_in_owner = true
-script = ExtResource("5_vdqda")
-
-[node name="CloneableComponent" type="Node" parent="."]
-unique_name_in_owner = true
-script = ExtResource("2_peemv")
-
-[node name="MergeEffectSource" type="Node" parent="CloneableComponent" node_paths=PackedStringArray("Cloneable", "OriginalSpriteAnchor", "MergeSound")]
-script = ExtResource("31_mergeeffect")
-Cloneable = NodePath("..")
-OriginalSpriteAnchor = NodePath("../../SpriteAnchor")
-GhostShader = ExtResource("30_ghostshader")
-GhostColor = Color(0.921569, 0.203922, 0.607843, 1)
-MergeSound = NodePath("AudioStreamPlayer2D")
-
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="CloneableComponent/MergeEffectSource"]
-stream = ExtResource("6_tkj71")
-
-[node name="FreezableComponent" parent="." instance=ExtResource("4_a4a8l")]
-
-[node name="InventoryComponent" type="Node2D" parent="." node_paths=PackedStringArray("OwnerCharacter")]
-script = ExtResource("4_vvdcd")
-OwnerCharacter = NodePath("..")
-metadata/_custom_type_script = "uid://cgtxr8m2no0u6"
-
-[node name="PelletShooter" parent="InventoryComponent" instance=ExtResource("5_gxkbl")]
-
-[node name="CameraOffset" type="Node2D" parent="."]
-
-[node name="Camera2D" type="Camera2D" parent="CameraOffset"]
-
-[node name="MovementStateMachine" type="Node" parent="." node_paths=PackedStringArray("InitialState")]
-script = ExtResource("3_677pu")
-InitialState = NodePath("Idle State")
-metadata/_custom_type_script = "uid://cnt6dnn0xqp5j"
-
-[node name="Idle State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("MoveState", "AirState", "MergeHoldState", "SplitState")]
-script = ExtResource("4_peemv")
-MoveState = NodePath("../Move State")
-AirState = NodePath("../Air State")
-MergeHoldState = NodePath("../Merge Hold State")
-SplitState = NodePath("../Split State")
-
-[node name="CameraShiftBehavior" type="Node" parent="MovementStateMachine/Idle State"]
-script = ExtResource("19_camshift")
+[node name="CameraShiftBehavior" type="Node" parent="MovementStateMachine/Idle State" index="0"]
+script = ExtResource("5_camshift")
 ShiftHoldDelay = 1.0
 
-[node name="Move State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("IdleState", "AirState", "SplitState", "MergeHoldState")]
-script = ExtResource("5_xloa1")
-IdleState = NodePath("../Idle State")
-AirState = NodePath("../Air State")
-SplitState = NodePath("../Split State")
-MergeHoldState = NodePath("../Merge Hold State")
-
-[node name="Air State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("IdleState", "SplitState", "MergeHoldState")]
-script = ExtResource("6_4b18b")
-IdleState = NodePath("../Idle State")
-SplitState = NodePath("../Split State")
-MergeHoldState = NodePath("../Merge Hold State")
-
-[node name="Split State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("IdleState")]
-script = ExtResource("8_omicx")
-IdleState = NodePath("../Idle State")
-
-[node name="PlaySoundBehavior" type="Node" parent="MovementStateMachine/Split State" node_paths=PackedStringArray("Sound")]
-script = ExtResource("12_14sst")
-Sound = NodePath("../../../Sounds/Dash")
-metadata/_custom_type_script = "uid://duuxf7bmm26wh"
-
-[node name="DashGhostTrailBehavior" type="Node" parent="MovementStateMachine/Split State" node_paths=PackedStringArray("SpriteAnchor")]
-script = ExtResource("29_dashghost")
-SpriteAnchor = NodePath("../../../SpriteAnchor")
-GhostShader = ExtResource("30_ghostshader")
-GhostColor = Color(0.92156863, 0.20392157, 0.60784316, 0.49803922)
-GhostLifetime = 0.25
-
-[node name="Merge Hold State" type="Node" parent="MovementStateMachine" node_paths=PackedStringArray("IdleState")]
-script = ExtResource("9_mergehold")
-IdleState = NodePath("../Idle State")
-
-[node name="Noclip State" type="Node" parent="MovementStateMachine"]
-script = ExtResource("18_noclip")
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(0, -5)
-shape = SubResource("RectangleShape2D_xloa1")
-
-[node name="HealthComponent" type="Node" parent="."]
-script = ExtResource("11_fgiha")
-MaxHealth = 100
-CurrentHealth = 100
-
-[node name="DeathHandler" type="Node" parent="HealthComponent" node_paths=PackedStringArray("Character", "DeathOverlay")]
-script = ExtResource("12_pv7kk")
+[node name="DeathHandler" type="Node" parent="HealthComponent" index="1" node_paths=PackedStringArray("Character", "DeathOverlay")]
+script = ExtResource("2_death")
 Character = NodePath("../..")
 DeathOverlay = NodePath("../../CanvasLayer/DeathOverlay")
 DeathFadeSpeed = 0.5
 
-[node name="DamageEffectSource" type="Node" parent="HealthComponent" node_paths=PackedStringArray("DamageSound", "Health", "Camera", "SpriteAnchor", "Character")]
-script = ExtResource("13_source")
-DamageSound = NodePath("../../Sounds/Hurt")
-Health = NodePath("..")
-Camera = NodePath("../../CameraOffset/Camera2D")
-SpriteAnchor = NodePath("../../SpriteAnchor")
-Character = NodePath("../..")
-DamageToIntensity = 0.4
-MinimumIntensity = 0.25
-SpriteHighlightGain = 1.5
+[node name="CameraOffset" type="Node2D" parent="." index="11"]
 
-[node name="Hurtbox" type="Area2D" parent="." node_paths=PackedStringArray("HealthComponent", "OwnerCharacter")]
-position = Vector2(0, -5)
-collision_layer = 256
-collision_mask = 512
-script = ExtResource("11_p3cti")
-HealthComponent = NodePath("../HealthComponent")
-OwnerCharacter = NodePath("..")
+[node name="Camera2D" type="Camera2D" parent="CameraOffset" index="0"]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Hurtbox"]
-shape = SubResource("RectangleShape2D_fgiha")
+[node name="CanvasLayer" type="CanvasLayer" parent="." index="12"]
 
-[node name="CanvasLayer" type="CanvasLayer" parent="."]
-
-[node name="PlayerHud" parent="CanvasLayer" node_paths=PackedStringArray("character") instance=ExtResource("14_fgvlp")]
+[node name="PlayerHud" parent="CanvasLayer" index="0" node_paths=PackedStringArray("character") instance=ExtResource("3_hud")]
 unique_name_in_owner = true
 character = NodePath("../..")
 
-[node name="DeathOverlay" type="ColorRect" parent="CanvasLayer"]
+[node name="DeathOverlay" type="ColorRect" parent="CanvasLayer" index="1"]
 visible = false
 anchors_preset = 15
 anchor_right = 1.0
@@ -186,45 +38,12 @@ grow_vertical = 2
 mouse_filter = 2
 color = Color(0, 0, 0, 1)
 
-[node name="SpriteAnchor" type="Node2D" parent="."]
-
-[node name="Sprite2D" type="Sprite2D" parent="SpriteAnchor"]
-texture_filter = 1
-position = Vector2(0, -8)
-scale = Vector2(0.125, 0.125)
-texture = ExtResource("15_5ocvt")
-
-[node name="ArmAnchor" type="Node2D" parent="SpriteAnchor"]
-position = Vector2(-3, -7)
-
-[node name="Sprite2D" type="Sprite2D" parent="SpriteAnchor/ArmAnchor"]
-scale = Vector2(0.125, 0.125)
-texture = ExtResource("16_5ocvt")
-
-[node name="AnimationPlayer" type="AnimationPlayer" parent="." node_paths=PackedStringArray("PlayerCharacter", "BodyAnchor", "ArmAnchor")]
-script = ExtResource("17_pv7kk")
-PlayerCharacter = NodePath("..")
-BodyAnchor = NodePath("../SpriteAnchor")
-ArmAnchor = NodePath("../SpriteAnchor/ArmAnchor")
-
-[node name="CanvasLayer2" type="CanvasLayer" parent="."]
+[node name="CanvasLayer2" type="CanvasLayer" parent="." index="13"]
 layer = 2
 
-[node name="PauseMenu" parent="CanvasLayer2" node_paths=PackedStringArray("character") instance=ExtResource("15_gxkbl")]
+[node name="PauseMenu" parent="CanvasLayer2" index="0" node_paths=PackedStringArray("character") instance=ExtResource("4_pause")]
 unique_name_in_owner = true
 character = NodePath("../..")
 
-[node name="Sounds" type="Node2D" parent="."]
-
-[node name="Dash" type="AudioStreamPlayer2D" parent="Sounds"]
-stream = ExtResource("23_ss146")
-volume_db = -5.0
-bus = &"SFX"
-
-[node name="Hurt" type="AudioStreamPlayer2D" parent="Sounds"]
-stream = ExtResource("25_cgsnx")
-volume_db = 3.0
-bus = &"SFX"
-
-[node name="AudioListener2D" type="AudioListener2D" parent="."]
+[node name="AudioListener2D" type="AudioListener2D" parent="." index="14"]
 current = true

--- a/Characters/CloneCharacter.tscn
+++ b/Characters/CloneCharacter.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://bgrbfq7lndxd4"]
+
+[ext_resource type="PackedScene" uid="uid://dbrsyvtefql5h" path="res://Characters/BaseCharacter.tscn" id="1_base"]
+[ext_resource type="Script" uid="uid://yrn61grlcn63" path="res://Characters/CloneDeathHandler.cs" id="2_d1p6b"]
+
+[node name="Character" instance=ExtResource("1_base")]
+
+[node name="DeathHandler" type="Node" parent="HealthComponent" index="1" node_paths=PackedStringArray("Character")]
+script = ExtResource("2_d1p6b")
+Character = NodePath("../..")

--- a/Characters/CloneDeathHandler.cs
+++ b/Characters/CloneDeathHandler.cs
@@ -1,0 +1,38 @@
+using Godot;
+
+namespace CrossedDimensions.Characters;
+
+/// <summary>
+/// Handles clone-specific death behavior by merging the clone back into its
+/// original character.
+/// </summary>
+public partial class CloneDeathHandler : Node
+{
+    [Export]
+    public Character Character { get; set; }
+
+    public override void _Ready()
+    {
+        if (Character?.Health is not null)
+        {
+            Character.Health.HealthChanged += OnHealthChanged;
+        }
+    }
+
+    private void OnHealthChanged(int oldHealth)
+    {
+        if (Character?.Health is null || Character.Health.IsAlive)
+        {
+            return;
+        }
+
+        if (Character.Cloneable?.IsClone != true)
+        {
+            return;
+        }
+
+        var originalCloneable = Character.Cloneable.Original?.Cloneable;
+        originalCloneable?.ClearHealingPool();
+        originalCloneable?.Merge();
+    }
+}

--- a/Characters/CloneDeathHandler.cs.uid
+++ b/Characters/CloneDeathHandler.cs.uid
@@ -1,0 +1,1 @@
+uid://yrn61grlcn63

--- a/Characters/CloneableComponent.cs
+++ b/Characters/CloneableComponent.cs
@@ -8,6 +8,8 @@ namespace CrossedDimensions.Characters;
 /// </summary>
 public sealed partial class CloneableComponent : Node
 {
+    private const string CloneScenePath = "res://Characters/CloneCharacter.tscn";
+
     public Character Character => GetParent<Character>();
 
     /// <summary>
@@ -161,11 +163,18 @@ public sealed partial class CloneableComponent : Node
         LastMirrorId = ulong.MaxValue;
         HealingPool = 0f;
 
-        var clone = (Character)Character.Duplicate();
+        var cloneScene = ResourceLoader.Load<PackedScene>(CloneScenePath);
+        var clone = cloneScene?.Instantiate<Character>();
+        if (clone is null)
+        {
+            GD.PushError($"CloneableComponent: failed to instantiate '{CloneScenePath}'.");
+            return null;
+        }
 
         var clonesComponent = clone
             .GetNode<CloneableComponent>("%CloneableComponent");
         clonesComponent.Original = Character;
+        CopySplitStateToClone(clone);
         clone.Controller.XScale *= -1;
 
         Clone = clone;
@@ -181,7 +190,6 @@ public sealed partial class CloneableComponent : Node
         EmitSignal(SignalName.CharacterSplit, Character, clone);
 
         SplitHealth(Character, clone);
-        RemoveCameraFromClone(clone);
 
         // add clone to the same parent as the original character
         // so that they are siblings in the scene tree
@@ -194,6 +202,25 @@ public sealed partial class CloneableComponent : Node
         return clone;
     }
 
+    private void CopySplitStateToClone(Character clone)
+    {
+        clone.GlobalPosition = Character.GlobalPosition;
+        clone.GlobalRotation = Character.GlobalRotation;
+        clone.Scale = Character.Scale;
+        clone.Velocity = Character.Velocity;
+        clone.VelocityFromInput = Character.VelocityFromInput;
+        clone.VelocityFromExternalForces = Character.VelocityFromExternalForces;
+        clone.JumpHeldAtTime = Character.JumpHeldAtTime;
+        clone.JumpReleasedAtTime = Character.JumpReleasedAtTime;
+        clone.JumpGravBoostTime = Character.JumpGravBoostTime;
+        clone.AllowJumpInput = Character.AllowJumpInput;
+        if (Character.Freezable?.IsFrozen ?? false)
+        {
+            clone.Freezable?.Freeze(Character.Freezable.TimeLeft);
+        }
+        clone.Inventory?.SyncWeaponsFrom(Character.Inventory);
+    }
+
     private void SplitHealth(Character original, Character clone)
     {
         int cloneHealth = original.Health.CurrentHealth / 2;
@@ -204,14 +231,6 @@ public sealed partial class CloneableComponent : Node
 
         original.Health.SetStats(originalHealth, originalMaxHealth);
         clone.Health.SetStats(cloneHealth, cloneMaxHealth);
-    }
-
-    private void RemoveCameraFromClone(Character clone)
-    {
-        if (clone.HasNode<Camera2D>("CameraOffset/Camera2D", out var camera))
-        {
-            camera.QueueFree();
-        }
     }
 
     public void TryMergeOnSplitRelease()

--- a/Characters/CloneableComponent.cs
+++ b/Characters/CloneableComponent.cs
@@ -1,4 +1,5 @@
 using Godot;
+using System.Threading.Tasks;
 using CrossedDimensions.Extensions;
 
 namespace CrossedDimensions.Characters;
@@ -9,6 +10,10 @@ namespace CrossedDimensions.Characters;
 public sealed partial class CloneableComponent : Node
 {
     private const string CloneScenePath = "res://Characters/CloneCharacter.tscn";
+    private static readonly PackedScene CloneScene = GD.Load<PackedScene>(CloneScenePath);
+
+    private Task<Character> _prepareCloneTask;
+    private bool _isExitingTree;
 
     public Character Character => GetParent<Character>();
 
@@ -134,6 +139,26 @@ public sealed partial class CloneableComponent : Node
 
     private double CurrentTime => Time.GetTicksMsec() / 1000.0;
 
+    public override void _Ready()
+    {
+        if (!IsClone)
+        {
+            QueueClonePreparation();
+        }
+    }
+
+    public override void _ExitTree()
+    {
+        _isExitingTree = true;
+
+        if (_prepareCloneTask is { IsCompletedSuccessfully: true })
+        {
+            _prepareCloneTask.Result?.Free();
+        }
+
+        _prepareCloneTask = null;
+    }
+
     public override void _PhysicsProcess(double delta)
     {
         if (Character?.Controller is null)
@@ -163,8 +188,7 @@ public sealed partial class CloneableComponent : Node
         LastMirrorId = ulong.MaxValue;
         HealingPool = 0f;
 
-        var cloneScene = ResourceLoader.Load<PackedScene>(CloneScenePath);
-        var clone = cloneScene?.Instantiate<Character>();
+        var clone = TakePreparedCloneOrInstantiateBlocking();
         if (clone is null)
         {
             GD.PushError($"CloneableComponent: failed to instantiate '{CloneScenePath}'.");
@@ -198,6 +222,7 @@ public sealed partial class CloneableComponent : Node
         EmitSignal(SignalName.CharacterSplitPost, Character, clone);
 
         _splitMergeWindowEndTime = CurrentTime + SplitMergeWindowDuration;
+        QueueClonePreparation();
 
         return clone;
     }
@@ -219,6 +244,50 @@ public sealed partial class CloneableComponent : Node
             clone.Freezable?.Freeze(Character.Freezable.TimeLeft);
         }
         clone.Inventory?.SyncWeaponsFrom(Character.Inventory);
+    }
+
+    private Character TakePreparedCloneOrInstantiateBlocking()
+    {
+        if (_prepareCloneTask is null)
+        {
+            return CloneScene?.Instantiate<Character>();
+        }
+
+        try
+        {
+            var clone = _prepareCloneTask.GetAwaiter().GetResult();
+            _prepareCloneTask = null;
+            return clone;
+        }
+        catch (System.Exception ex)
+        {
+            GD.PushWarning($"CloneableComponent: clone prewarm failed ({ex.Message}). Falling back to direct instantiate.");
+            _prepareCloneTask = null;
+            return CloneScene?.Instantiate<Character>();
+        }
+    }
+
+    private void QueueClonePreparation()
+    {
+        if (IsClone || _isExitingTree)
+        {
+            return;
+        }
+
+        if (_prepareCloneTask is not null && !_prepareCloneTask.IsCompleted)
+        {
+            return;
+        }
+
+        _prepareCloneTask = Task.Run(() =>
+        {
+            if (_isExitingTree)
+            {
+                return null;
+            }
+
+            return CloneScene?.Instantiate<Character>();
+        });
     }
 
     private void SplitHealth(Character original, Character clone)

--- a/Characters/CloneableComponent.cs
+++ b/Characters/CloneableComponent.cs
@@ -253,18 +253,9 @@ public sealed partial class CloneableComponent : Node
             return CloneScene?.Instantiate<Character>();
         }
 
-        try
-        {
-            var clone = _prepareCloneTask.GetAwaiter().GetResult();
-            _prepareCloneTask = null;
-            return clone;
-        }
-        catch (System.Exception ex)
-        {
-            GD.PushWarning($"CloneableComponent: clone prewarm failed ({ex.Message}). Falling back to direct instantiate.");
-            _prepareCloneTask = null;
-            return CloneScene?.Instantiate<Character>();
-        }
+        var clone = _prepareCloneTask.GetAwaiter().GetResult();
+        _prepareCloneTask = null;
+        return clone;
     }
 
     private void QueueClonePreparation()

--- a/Components/InventoryComponent.cs
+++ b/Components/InventoryComponent.cs
@@ -303,6 +303,38 @@ public partial class InventoryComponent : Node2D
         }
     }
 
+    public void SyncWeaponsFrom(InventoryComponent source)
+    {
+        if (source is null)
+        {
+            return;
+        }
+
+        foreach (var weapon in GetChildren().OfType<Weapon>().ToList())
+        {
+            RemoveChild(weapon);
+            weapon.Free();
+        }
+
+        EquippedWeapon = null;
+
+        foreach (var weapon in source.GetChildren().OfType<Weapon>())
+        {
+            var weaponClone = weapon.Duplicate() as Weapon;
+            if (weaponClone is null)
+            {
+                continue;
+            }
+
+            AddChild(weaponClone);
+        }
+
+        if (source.EquippedWeapon is not null)
+        {
+            EquipWeaponByName(source.EquippedWeapon.Name, recursive: false);
+        }
+    }
+
     /// <summary>
     /// Equip the specified weapon. This will deactivate tously
     /// equipped weapon (if any), activate the new weapon, update the weapon's

--- a/CrossedDimensions.Tests/GodotHeadlessFixedFpsFixture.cs
+++ b/CrossedDimensions.Tests/GodotHeadlessFixedFpsFixture.cs
@@ -11,22 +11,10 @@ public class GodotHeadlessFixedFpsFixture : GodotHeadlessFixture
         // doubling playback speed so tests run faster but still exercise
         // animation-driven flows.
         CrossedDimensions.Saves.SceneManager.CutscenePlaybackSpeed = 16.0;
-
-        // If the ScreenOverlayManager singleton has been readied, also bump
-        // its fade playback speed. Use the singleton Instance property which
-        // is set in ScreenOverlayManager._Ready(). If it's not available yet,
-        // tests can still set it later in their setup.
-        try
+        var overlay = CrossedDimensions.UI.ScreenOverlayManager.Instance;
+        if (overlay is not null && Godot.GodotObject.IsInstanceValid(overlay))
         {
-            var overlay = CrossedDimensions.UI.ScreenOverlayManager.Instance;
-            if (overlay is not null && Godot.GodotObject.IsInstanceValid(overlay))
-            {
-                overlay.FadePlaybackSpeed = 16.0;
-            }
-        }
-        catch
-        {
-            // Ignore any issues here; it's only an opportunistic speedup.
+            overlay.FadePlaybackSpeed = 16.0;
         }
     }
 }

--- a/CrossedDimensions.Tests/GodotHeadlessFixedFpsFixture.cs
+++ b/CrossedDimensions.Tests/GodotHeadlessFixedFpsFixture.cs
@@ -7,5 +7,26 @@ public class GodotHeadlessFixedFpsFixture : GodotHeadlessFixture
         // Set max FPS after Godot has initialized
         Godot.Engine.Singleton.MaxFps = 60;
         Godot.Engine.PhysicsTicksPerSecond = 60;
+        // Speed up animations used by tests (cutscenes, fades). Default to
+        // doubling playback speed so tests run faster but still exercise
+        // animation-driven flows.
+        CrossedDimensions.Saves.SceneManager.CutscenePlaybackSpeed = 16.0;
+
+        // If the ScreenOverlayManager singleton has been readied, also bump
+        // its fade playback speed. Use the singleton Instance property which
+        // is set in ScreenOverlayManager._Ready(). If it's not available yet,
+        // tests can still set it later in their setup.
+        try
+        {
+            var overlay = CrossedDimensions.UI.ScreenOverlayManager.Instance;
+            if (overlay is not null && Godot.GodotObject.IsInstanceValid(overlay))
+            {
+                overlay.FadePlaybackSpeed = 16.0;
+            }
+        }
+        catch
+        {
+            // Ignore any issues here; it's only an opportunistic speedup.
+        }
     }
 }

--- a/CrossedDimensions.Tests/Integration/CloneableComponentIntegrationTest.cs
+++ b/CrossedDimensions.Tests/Integration/CloneableComponentIntegrationTest.cs
@@ -80,6 +80,18 @@ public class CloneableComponentIntegrationTest : IDisposable
     }
 
     [Fact]
+    public void CloneableComponent_Split_ShouldUseCloneSceneWithoutPlayerOnlyNodes()
+    {
+        var clone = _character.Cloneable.Split();
+
+        clone.HasNode("Camera2D").ShouldBeFalse();
+        clone.HasNode("CanvasLayer").ShouldBeFalse();
+        clone.HasNode("CanvasLayer2").ShouldBeFalse();
+        clone.HasNode("AudioListener2D").ShouldBeFalse();
+        clone.IsInGroup("Player").ShouldBeTrue();
+    }
+
+    [Fact]
     public void CloneableComponent_Mirror_WhenOriginal_ShouldReturnItsClone()
     {
         var clone = _character.Cloneable.Split();
@@ -149,6 +161,17 @@ public class CloneableComponentIntegrationTest : IDisposable
         var clone = _character.Cloneable.Split();
 
         clone.Cloneable.Merge();
+
+        _character.Cloneable.Clone.ShouldBeNull();
+        clone.IsQueuedForDeletion().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CloneableComponent_WhenCloneDies_ShouldMergeBackIntoOriginal()
+    {
+        var clone = _character.Cloneable.Split();
+
+        clone.Health.CurrentHealth = 0;
 
         _character.Cloneable.Clone.ShouldBeNull();
         clone.IsQueuedForDeletion().ShouldBeTrue();

--- a/CrossedDimensions.Tests/Integration/Cutscene/CutsceneTransitionCutsceneScene.tscn
+++ b/CrossedDimensions.Tests/Integration/Cutscene/CutsceneTransitionCutsceneScene.tscn
@@ -5,7 +5,7 @@
 
 [sub_resource type="Animation" id="Animation_cutscene_play"]
 resource_name = "cutscene_play"
-length = 1.0
+length = 0.05
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -13,7 +13,7 @@ tracks/0/path = NodePath("AnimatedProp:position")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1),
+"times": PackedFloat32Array(0, 0.05),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
 "values": [Vector2(0, 0), Vector2(96, 0)]

--- a/CrossedDimensions.Tests/Integration/Cutscene/CutsceneTransitionIntegrationTest.cs
+++ b/CrossedDimensions.Tests/Integration/Cutscene/CutsceneTransitionIntegrationTest.cs
@@ -42,6 +42,7 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
         _sceneManager = _godot.Tree.Root.GetNode<SceneManager>("/root/SceneManager");
         _screenOverlay = _godot.Tree.Root.GetNode<ScreenOverlayManager>(
             "/root/ScreenOverlayManager");
+        // Fade playback speed is set at fixture level.
         _originalScene = _godot.Tree.CurrentScene;
         _originalSave = _saveManager.CurrentSave;
         _saveManager.CurrentSave = new SaveFile();
@@ -173,7 +174,7 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
         _godot.GodotInstance
             .IterateUntil(
                 () => IsGameplaySceneRestored() && _sceneManager.ActiveCutsceneScene is null,
-                240)
+                120)
             .ShouldBeTrue();
     }
 
@@ -219,7 +220,7 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
                     () => IsGameplaySceneRestored()
                         && _sceneManager.ActiveCutsceneScene is null
                         && !_screenOverlay.FadeOverlay.Visible,
-                    360)
+                    180)
                 .ShouldBeTrue();
 
             _gameplayScene.GetParent().ShouldNotBeNull();
@@ -292,7 +293,7 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
                 .IterateUntil(
                     () => IsGameplaySceneRestored()
                         && _sceneManager.ActiveCutsceneScene is null,
-                    360)
+                    180)
                 .ShouldBeTrue();
 
             addedCount.ShouldBe(0);
@@ -312,12 +313,12 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
         TriggerCutscene(trigger);
         WaitForCutsceneLoaded();
 
-        _godot.GodotInstance
-            .IterateUntil(
-                () => IsGameplaySceneRestored()
-                    && _sceneManager.ActiveCutsceneScene is null,
-                360)
-            .ShouldBeTrue();
+            _godot.GodotInstance
+                .IterateUntil(
+                    () => IsGameplaySceneRestored()
+                        && _sceneManager.ActiveCutsceneScene is null,
+                    180)
+                .ShouldBeTrue();
 
         TriggerCutscene(trigger);
         _godot.GodotInstance.Iteration(10);
@@ -327,12 +328,12 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
         TriggerCutscene(trigger);
 
         WaitForCutsceneLoaded().ShouldNotBeNull();
-        _godot.GodotInstance
-            .IterateUntil(
-                () => IsGameplaySceneRestored()
-                    && _sceneManager.ActiveCutsceneScene is null,
-                360)
-            .ShouldBeTrue();
+            _godot.GodotInstance
+                .IterateUntil(
+                    () => IsGameplaySceneRestored()
+                        && _sceneManager.ActiveCutsceneScene is null,
+                    180)
+                .ShouldBeTrue();
     }
 
     [Fact]
@@ -347,7 +348,7 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
             .IterateUntil(
                 () => IsGameplaySceneRestored()
                     && _sceneManager.ActiveCutsceneScene is null,
-                360)
+                120)
             .ShouldBeTrue();
 
         _godot.GodotInstance
@@ -382,7 +383,7 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
             .IterateUntil(
                 () => IsGameplaySceneRestored()
                     && _sceneManager.ActiveCutsceneScene is null,
-                360)
+                120)
             .ShouldBeTrue();
 
         var restoredTrigger = CreateTrigger(
@@ -411,13 +412,13 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
             .IterateUntil(
                 () => IsGameplaySceneRestored()
                     && _sceneManager.ActiveCutsceneScene is null,
-                360)
+                120)
             .ShouldBeTrue();
 
         _godot.GodotInstance
             .IterateUntil(
                 () => _gameplayScene.GetNodeOrNull<CutsceneTrigger>(triggerName) is null,
-                240)
+                120)
             .ShouldBeTrue();
     }
 
@@ -467,7 +468,7 @@ public sealed class CutsceneTransitionIntegrationTest : IDisposable
     private void WaitForCutsceneStart(CutsceneScene cutscene)
     {
         _godot.GodotInstance
-            .IterateUntil(() => cutscene.IsStarted, 120)
+            .IterateUntil(() => cutscene.IsStarted, 60)
             .ShouldBeTrue();
     }
 

--- a/Saves/SceneManager.cs
+++ b/Saves/SceneManager.cs
@@ -16,6 +16,11 @@ namespace CrossedDimensions.Saves;
 [GlobalClass]
 public partial class SceneManager : Node
 {
+    /// <summary>
+    /// Multiplier applied to cutscene animation playback speed. Tests can set
+    /// this to accelerate cutscenes; default 1.0 preserves normal behaviour.
+    /// </summary>
+    public static double CutscenePlaybackSpeed { get; set; } = 1.0;
     [Signal]
     public delegate void CutsceneLoadedEventHandler(string scenePath);
 
@@ -138,13 +143,15 @@ public partial class SceneManager : Node
                     && !string.IsNullOrEmpty(animationName))
                 {
                     var animation = cutsceneRoot.AnimationPlayer.GetAnimation(animationName);
-                    if (animation is not null)
-                    {
-                        cutsceneRoot.AnimationPlayer.Play(animationName);
-                        await ToSignal(
-                            cutsceneRoot.AnimationPlayer,
-                            AnimationPlayer.SignalName.AnimationFinished);
-                    }
+                        if (animation is not null)
+                        {
+                            // Allow tests to speed up cutscene playback via
+                            // SceneManager.CutscenePlaybackSpeed.
+                            cutsceneRoot.AnimationPlayer.Play(animationName, CutscenePlaybackSpeed);
+                            await ToSignal(
+                                cutsceneRoot.AnimationPlayer,
+                                AnimationPlayer.SignalName.AnimationFinished);
+                        }
                 }
 
                 cutsceneRoot.IsFinished = true;

--- a/Saves/SceneManager.cs
+++ b/Saves/SceneManager.cs
@@ -143,15 +143,15 @@ public partial class SceneManager : Node
                     && !string.IsNullOrEmpty(animationName))
                 {
                     var animation = cutsceneRoot.AnimationPlayer.GetAnimation(animationName);
-                        if (animation is not null)
-                        {
-                            // Allow tests to speed up cutscene playback via
-                            // SceneManager.CutscenePlaybackSpeed.
-                            cutsceneRoot.AnimationPlayer.Play(animationName, CutscenePlaybackSpeed);
-                            await ToSignal(
-                                cutsceneRoot.AnimationPlayer,
-                                AnimationPlayer.SignalName.AnimationFinished);
-                        }
+                    if (animation is not null)
+                    {
+                        // Allow tests to speed up cutscene playback via
+                        // SceneManager.CutscenePlaybackSpeed.
+                        cutsceneRoot.AnimationPlayer.Play(animationName, CutscenePlaybackSpeed);
+                        await ToSignal(
+                            cutsceneRoot.AnimationPlayer,
+                            AnimationPlayer.SignalName.AnimationFinished);
+                    }
                 }
 
                 cutsceneRoot.IsFinished = true;

--- a/Saves/SceneManager.cs
+++ b/Saves/SceneManager.cs
@@ -420,6 +420,7 @@ public partial class SceneManager : Node
         var player = GetTree()
             .GetNodesInGroup("Player")
             .OfType<Characters.Character>()
+            .OrderBy(p => p.Cloneable?.IsClone ?? false)
             .FirstOrDefault();
 
         return player?.GlobalPosition ?? Vector2.Zero;

--- a/UI/ScreenOverlayManager.cs
+++ b/UI/ScreenOverlayManager.cs
@@ -35,6 +35,12 @@ public partial class ScreenOverlayManager : CanvasLayer
 
     [Export]
     public float FadeDuration { get; set; } = 0.4f;
+    
+    /// <summary>
+    /// Playback speed multiplier applied when playing fade animations. Useful
+    /// for tests to accelerate fades without changing the animation resources.
+    /// </summary>
+    public double FadePlaybackSpeed { get; set; } = 1.0;
 
     /// <summary>
     /// A full-screen ColorRect whose material uses DamageVignette.gdshader.
@@ -143,7 +149,8 @@ public partial class ScreenOverlayManager : CanvasLayer
         EmitSignal(SignalName.FadeInStarted);
         FadeOverlay.Modulate = new Color(0, 0, 0, 0);
         FadeOverlay.Visible = true;
-        FadeAnimationPlayer.Play("fade_in");
+        // Use FadePlaybackSpeed so tests can accelerate fades if needed.
+        FadeAnimationPlayer.Play("fade_in", FadePlaybackSpeed);
         await ToSignal(FadeAnimationPlayer, AnimationPlayer.SignalName.AnimationFinished);
         EmitSignal(SignalName.FadeInCompleted);
     }
@@ -152,7 +159,7 @@ public partial class ScreenOverlayManager : CanvasLayer
     public async Task FadeOut()
     {
         EmitSignal(SignalName.FadeOutStarted);
-        FadeAnimationPlayer.Play("fade_out");
+        FadeAnimationPlayer.Play("fade_out", FadePlaybackSpeed);
         await ToSignal(FadeAnimationPlayer, AnimationPlayer.SignalName.AnimationFinished);
         FadeOverlay.Visible = false;
         EmitSignal(SignalName.FadeOutCompleted);

--- a/UI/ScreenOverlayManager.cs
+++ b/UI/ScreenOverlayManager.cs
@@ -35,7 +35,7 @@ public partial class ScreenOverlayManager : CanvasLayer
 
     [Export]
     public float FadeDuration { get; set; } = 0.4f;
-    
+
     /// <summary>
     /// Playback speed multiplier applied when playing fade animations. Useful
     /// for tests to accelerate fades without changing the animation resources.

--- a/UI/UIPauseMenu/pause_menu.gd
+++ b/UI/UIPauseMenu/pause_menu.gd
@@ -3,11 +3,9 @@ extends Control
 @onready var scene_manager: SceneManager
 @onready var settings_menu : SettingsSelector
 @onready var save_manager: SaveManager
-var clone: Character
 func _ready():
 	$AnimationPlayer.play("RESET")
 	hide()
-	character.Cloneable.connect(&"CharacterSplitPost", _on_character_split)
 	scene_manager = get_node("/root/SceneManager")
 	settings_menu = $SettingSelectMenu
 	save_manager = get_node("/root/SaveManager")
@@ -28,9 +26,6 @@ func resume():
 	get_tree().paused = false
 	$AnimationPlayer.play_backwards("blur")
 	hide()
-func _on_character_split(_orig_character, clone_character: Character):
-	clone = clone_character
-	clone_character.get_node("%PauseMenu").queue_free()
 
 func openSettings(): #not implemented
 	settings_menu.open_settings()

--- a/UI/UIPlayerHud/player_hud.gd
+++ b/UI/UIPlayerHud/player_hud.gd
@@ -1,11 +1,11 @@
 extends Node
 #creates health_bar variable of type HealthBar and assigns it the value
-#of the HealthBars Node when the PlayerHud Node gets added to the scean tree. 
+#of the HealthBars Node when the PlayerHud Node gets added to the scean tree.
 @onready var health_bars: HealthBars = $HealthBars
 @onready var clone_indicator: CloneOffscreenIndicator = $CloneOffscreenIndicator
-#creates characer varable of type Character, which is a class. @export 
+#creates characer varable of type Character, which is a class. @export
 # allows godot to define the object instance of character at runtime
-@export var character: Character 
+@export var character: Character
 var clone: Character
 #Summary
 #when PlayerHud is loaded into the main scean tree
@@ -19,11 +19,11 @@ func _ready() -> void:
 	character.Cloneable.connect(&"CharacterSplitPost", _on_character_split)
 	character.Cloneable.connect(&"CharacterMerged", _on_character_merge)
 	character.Cloneable.connect(&"HealingPoolChanged", _on_healing_pool_changed)
-	
+
 	if %InventoryBar != null:
 		%InventoryBar.SetInventory(character.Inventory)
 #_on_main_health_changed as parameter _old_health to catch
-# the emmited parameter of the HealthChanged signal 
+# the emmited parameter of the HealthChanged signal
 # new new_health is typed to int since the value
 # its reading is also typed to int
 #
@@ -41,11 +41,10 @@ func _on_clone_health_changed(_old_health: int):
 #Summary
 #Is called when the CharacterSplitPost signal is emmited
 #assigns the clone var to the instance of the clone that is made duing runtime
-#removes the PlayerHud node from the clone's scene tree. 
+#removes the PlayerHud node from the clone's scene tree.
 #connects _on_clone_health_changed with the clone's HealthChanged signal
 func _on_character_split(_orig_character, clone_character: Character):
 	clone = clone_character
-	clone_character.get_node("%PlayerHud").queue_free()
 	clone_character.Health.connect(&"HealthChanged", _on_clone_health_changed)
 	health_bars.main_health_bar.set_health_bar_half(character.Health.MaxHealth)
 	health_bars.clone_health_bar.set_health_bar_half(clone.Health.MaxHealth)


### PR DESCRIPTION
Splits the player and clone into separate scenes and also caches a new instance of the clone when splitting in a background thread. Closes #249 

---

This pull request refactors the character scene structure by introducing a new `BaseCharacter.tscn` scene, which consolidates all core character components and logic. The main `Character.tscn` and the new `CloneCharacter.tscn` now both instance this base scene, allowing for better code reuse and separation of player-specific, clone-specific, and shared logic. Additionally, a new `CloneDeathHandler` script is introduced to handle clone-specific death behavior.

**Scene structure refactor:**

- Introduced `BaseCharacter.tscn` to encapsulate all shared character components, logic, and nodes. Both `Character.tscn` (player) and the new `CloneCharacter.tscn` (clone) now instance this base scene, greatly reducing duplication and simplifying future maintenance. [[1]](diffhunk://#diff-a5e24688d73f8524b6b274ab022c790ed05e49f398a3d78bea2692f869e9a365R1-R185) [[2]](diffhunk://#diff-131a6cb9ecf101125933ec2a4704812df809a0632c867eba958891f586524106R1-R10) [[3]](diffhunk://#diff-08601e935a478d455eb1c4c2af70398089e8ba07ac53470c43329f4cd1d83300L1-R31)

- Moved all core character nodes (movement, health, inventory, visual nodes, sounds, etc.) from `Character.tscn` into `BaseCharacter.tscn`, leaving only player-specific or UI-related nodes in `Character.tscn`. [[1]](diffhunk://#diff-a5e24688d73f8524b6b274ab022c790ed05e49f398a3d78bea2692f869e9a365R1-R185) [[2]](diffhunk://#diff-08601e935a478d455eb1c4c2af70398089e8ba07ac53470c43329f4cd1d83300L1-R31) [[3]](diffhunk://#diff-08601e935a478d455eb1c4c2af70398089e8ba07ac53470c43329f4cd1d83300L189-R48)

**Clone system improvements:**

- Added `CloneCharacter.tscn` as a lightweight scene instancing `BaseCharacter.tscn` and adding only a `CloneDeathHandler` node for clone-specific logic.

- Implemented `CloneDeathHandler.cs`, which listens for the clone's death and triggers merging back into the original character, including clearing the healing pool. [[1]](diffhunk://#diff-4a5171c9c95c46e8e4ef45c9711e29973ed68a65111fa7333373d18a89b1e20cR1-R38) [[2]](diffhunk://#diff-ba11c402501cbbad20b204524bb9261b8535eb5dff7fb1ab86b528dcf6010aaeR1)

**Codebase and maintainability:**

- Updated `CloneableComponent.cs` to prepare for the new clone instancing workflow, including static loading of the `CloneCharacter.tscn` scene and internal state for asynchronous clone preparation. [[1]](diffhunk://#diff-5784dbc570d7a75a5f7c5ffb35c1bf079d275d0e635db1b4461a5c2b6bacfbbeR2) [[2]](diffhunk://#diff-5784dbc570d7a75a5f7c5ffb35c1bf079d275d0e635db1b4461a5c2b6bacfbbeR12-R17)