### PR TITLE
feature: Add ignorable groups to hitboxes

### DIFF
--- a/BoundingBoxes/Hitbox.cs
+++ b/BoundingBoxes/Hitbox.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Linq;
 using Godot;
+using Godot.Collections;
 
 namespace CrossedDimensions.BoundingBoxes;
 
@@ -35,6 +38,13 @@ public partial class Hitbox : BoundingBox
     /// </summary>
     [Export]
     public Timer LifetimeTimer { get; set; }
+
+    /// <summary>
+    /// List of groups for the hitbox to ignore when
+    /// colliding with a hurtbox.
+    /// </summary>
+    [Export]
+    public Array<string> IgnoreGroups = new Array<string>();
 
     [Signal]
     public delegate void HitEventHandler(Hitbox hitbox, Hurtbox hurtbox);
@@ -75,6 +85,14 @@ public partial class Hitbox : BoundingBox
             if (!CanHitSelf && hurtbox.OwnerCharacter == OwnerCharacter)
             {
                 return;
+            }
+
+            if (IgnoreGroups.Count != 0)
+            {
+                if (IgnoreGroups.Any(group => hurtbox.OwnerCharacter?.IsInGroup(group) ?? false))
+                {
+                    return;
+                }
             }
 
             if (hurtbox.Hit(this))

--- a/BoundingBoxes/Hitbox.cs
+++ b/BoundingBoxes/Hitbox.cs
@@ -87,12 +87,9 @@ public partial class Hitbox : BoundingBox
                 return;
             }
 
-            if (IgnoreGroups.Count != 0)
+            if (IgnoreGroups.Any(group => hurtbox.OwnerCharacter?.IsInGroup(group) ?? false))
             {
-                if (IgnoreGroups.Any(group => hurtbox.OwnerCharacter?.IsInGroup(group) ?? false))
-                {
-                    return;
-                }
+                return;
             }
 
             if (hurtbox.Hit(this))

--- a/CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs
+++ b/CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs
@@ -2,6 +2,8 @@ using CrossedDimensions.BoundingBoxes;
 using CrossedDimensions.Components;
 using CrossedDimensions.Characters;
 using Godot;
+using Godot.Collections;
+using System.Linq;
 
 namespace CrossedDimensions.Tests.BoundingBoxes;
 
@@ -231,5 +233,35 @@ public class HurtboxTest(GodotHeadlessFixedFpsFixture godot)
 
         scene.QueueFree();
         hitbox.QueueFree();
+    }
+
+    [Fact]
+    public void Hurtbox_ShouldIgnoreHitFrom_HitboxHasHurtboxOwnerGroupinIgnorableGroups()
+    {
+        
+        var scene = new Node2D();
+
+        var ownerCharacter = new Character();
+        ownerCharacter.AddToGroup("Player");
+
+        var hurtbox = new Hurtbox();
+        hurtbox.OwnerCharacter = ownerCharacter;
+
+        var hitbox = new Hitbox();
+        hitbox.IgnoreGroups = new Array<string> { "Player" };
+
+        scene.AddChild(ownerCharacter);
+        scene.AddChild(hurtbox);
+        scene.AddChild(hitbox);
+
+        bool shouldIgnore = hitbox.IgnoreGroups.Any(group => hurtbox.OwnerCharacter?.IsInGroup(group) ?? false);
+
+        Assert.True(shouldIgnore);
+
+        scene.QueueFree();
+        ownerCharacter.QueueFree();
+        hurtbox.QueueFree();
+        hitbox.QueueFree();
+
     }
 }

--- a/CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs
+++ b/CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs
@@ -238,8 +238,7 @@ public class HurtboxTest(GodotHeadlessFixedFpsFixture godot)
     [Fact]
     public void Hurtbox_ShouldIgnoreHitFrom_HitboxHasHurtboxOwnerGroupinIgnorableGroups()
     {
-        
-        var scene = new Node2D();
+        bool hitEmitted = false;
 
         var ownerCharacter = new Character();
         ownerCharacter.AddToGroup("Player");
@@ -249,19 +248,11 @@ public class HurtboxTest(GodotHeadlessFixedFpsFixture godot)
 
         var hitbox = new Hitbox();
         hitbox.IgnoreGroups = new Array<string> { "Player" };
+        hitbox.Hit += (h, hb) => hitEmitted = true;
 
-        scene.AddChild(ownerCharacter);
-        scene.AddChild(hurtbox);
-        scene.AddChild(hitbox);
+        hitbox.OnHitboxAreaEntered(hurtbox);
 
-        bool shouldIgnore = hitbox.IgnoreGroups.Any(group => hurtbox.OwnerCharacter?.IsInGroup(group) ?? false);
-
-        Assert.True(shouldIgnore);
-
-        scene.QueueFree();
-        ownerCharacter.QueueFree();
-        hurtbox.QueueFree();
-        hitbox.QueueFree();
+        Assert.False(hitEmitted);
 
     }
 }


### PR DESCRIPTION
Hitboxes have an exportable empty array of strings. A groups name goes in and the hitbox will now check if the hurtboxes owner character is in any of the given groups. If they are, the hurtbox is ignored.