### PR TITLE
fix: Resolve issues regarding merge mechanic

### DIFF
--- a/States/Characters/CharacterIdleState.cs
+++ b/States/Characters/CharacterIdleState.cs
@@ -45,16 +45,19 @@ public partial class CharacterIdleState : CharacterState
             return MoveState;
         }
 
-        // if splitting and movement key is held down
+        // Splitting from idle still needs directional input, but merging should
+        // work regardless of movement input when a clone already exists.
         var controller = CharacterContext.Controller;
-        if (controller.IsSplitting && !controller.MovementInput.IsZeroApprox())
+        if (controller.IsSplitting)
         {
             var cloneable = CharacterContext.Cloneable;
             if (cloneable is not null && !cloneable.IsClone)
             {
                 if (cloneable.Mirror is null)
                 {
-                    if (SplitState is CharacterSplitState splitState && splitState.CanSplit)
+                    if (!controller.MovementInput.IsZeroApprox()
+                        && SplitState is CharacterSplitState splitState
+                        && splitState.CanSplit)
                     {
                         return SplitState;
                     }

--- a/States/Characters/CharacterMergeHoldState.cs
+++ b/States/Characters/CharacterMergeHoldState.cs
@@ -12,6 +12,12 @@ public sealed partial class CharacterMergeHoldState : CharacterState
     public override State Enter(State previousState)
     {
         _healAccumulator = 0f;
+        if (CharacterContext.Cloneable.HealingPool <= 0f)
+        {
+            CharacterContext.Cloneable.Merge();
+            return previousState;
+        }
+
         CharacterContext.VelocityFromExternalForces = Vector2.Zero;
         CharacterContext.Velocity = Vector2.Zero;
         CharacterContext.Cloneable.Merge();


### PR DESCRIPTION
Closes #258 

---

This pull request updates the character splitting and merging logic to improve the handling of input requirements and edge cases. The main changes ensure that splitting from idle still requires directional input, while merging can proceed even without movement input if a clone already exists. Additionally, it adds a check to immediately merge if the healing pool is depleted when entering the merge state.

**Character splitting and merging logic improvements:**

* Updated `CharacterIdleState` so that splitting from idle still requires movement input, but merging is allowed regardless of movement input when a clone exists. This clarifies and corrects the input requirements for these actions.

* Modified `CharacterMergeHoldState` to immediately trigger a merge and revert to the previous state if the healing pool is depleted upon entering the state, preventing unnecessary processing.