### PR TITLE
tweak: Change health bar visuals

### DIFF
--- a/Assets/Textures/Player/clone-still.tres
+++ b/Assets/Textures/Player/clone-still.tres
@@ -1,0 +1,7 @@
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://0fj3eg36dxvv"]
+
+[ext_resource type="Texture2D" uid="uid://cbsqp0mmo0wu2" path="res://Assets/Textures/Player/clone.png" id="1_vq2k1"]
+
+[resource]
+atlas = ExtResource("1_vq2k1")
+region = Rect2(0, 0, 24, 24)

--- a/Assets/Textures/Player/shale-still.tres
+++ b/Assets/Textures/Player/shale-still.tres
@@ -1,0 +1,7 @@
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://iqb6h7koghwm"]
+
+[ext_resource type="Texture2D" uid="uid://b6pu8oaoukdec" path="res://Assets/Textures/Player/shale-2.png" id="1_6o1lf"]
+
+[resource]
+atlas = ExtResource("1_6o1lf")
+region = Rect2(0, 0, 24, 24)

--- a/UI/UIPlayerHud/CloneHealthl.tscn
+++ b/UI/UIPlayerHud/CloneHealthl.tscn
@@ -1,21 +1,21 @@
-[gd_scene load_steps=3 format=3 uid="uid://sipbcphr51xk"]
+[gd_scene load_steps=4 format=3 uid="uid://sipbcphr51xk"]
 
 [ext_resource type="PackedScene" uid="uid://bslsqvlms73qt" path="res://UI/UIPlayerHud/PlayerHealthBar.tscn" id="1_3kk7a"]
+[ext_resource type="Texture2D" uid="uid://0fj3eg36dxvv" path="res://Assets/Textures/Player/clone-still.tres" id="2_afkyo"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_puqrb"]
-bg_color = Color(0.45882353, 0.047058824, 0.54901963, 1)
+bg_color = Color(0.64517456, 0.16963005, 0.53777766, 1)
 
 [node name="CloneHealthBar" instance=ExtResource("1_3kk7a")]
 size_flags_horizontal = 0
 size_flags_vertical = 0
 
 [node name="ProgressBar" parent="." index="0"]
-offset_right = 70.0
-offset_bottom = 10.0
+offset_right = 62.0
+offset_bottom = 8.0
 theme_override_styles/fill = SubResource("StyleBoxFlat_puqrb")
 
 [node name="CharacterIcon" parent="." index="1"]
-offset_left = 8.0
-offset_top = 0.0
-offset_right = 18.0
-offset_bottom = 11.0
+offset_top = -1.0
+offset_bottom = 19.0
+texture = ExtResource("2_afkyo")

--- a/UI/UIPlayerHud/HealthBars.tscn
+++ b/UI/UIPlayerHud/HealthBars.tscn
@@ -8,7 +8,7 @@
 bg_color = Color(0, 0, 0, 0.23137255)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xhiqy"]
-bg_color = Color(0.7894578, 0.24303663, 0.92291534, 1)
+bg_color = Color(1.101372, 0.3608026, 1.286514, 1)
 
 [node name="HealthBars" type="Control"]
 layout_mode = 3
@@ -21,8 +21,8 @@ script = ExtResource("1_xhiqy")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0
-offset_right = 120.0
-offset_bottom = 43.0
+offset_right = 112.0
+offset_bottom = 40.0
 theme_override_constants/separation = 0
 
 [node name="PlayerHealthBar" parent="VBoxContainer" instance=ExtResource("1_7dnsh")]
@@ -30,13 +30,13 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
-custom_minimum_size = Vector2(10, 20)
+custom_minimum_size = Vector2(0, 12)
 layout_mode = 2
 
 [node name="MarginContainer2" type="MarginContainer" parent="VBoxContainer"]
 custom_minimum_size = Vector2(10, 4)
 layout_mode = 2
-theme_override_constants/margin_left = 20
+theme_override_constants/margin_left = 12
 
 [node name="HealPoolBar" type="ProgressBar" parent="VBoxContainer/MarginContainer2"]
 unique_name_in_owner = true
@@ -50,5 +50,4 @@ show_percentage = false
 
 [node name="CloneHealthBar" parent="VBoxContainer" instance=ExtResource("2_heaq6")]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2

--- a/UI/UIPlayerHud/PlayerHealthBar.tscn
+++ b/UI/UIPlayerHud/PlayerHealthBar.tscn
@@ -1,19 +1,21 @@
 [gd_scene load_steps=5 format=3 uid="uid://bslsqvlms73qt"]
 
 [ext_resource type="Script" uid="uid://berscce7ky2pi" path="res://UI/UIPlayerHud/player_health_bar.gd" id="1_4epgc"]
-[ext_resource type="Texture2D" uid="uid://dr1ss6b1in635" path="res://Assets/Textures/Player/shale-neutral.png" id="2_4epgc"]
+[ext_resource type="Texture2D" uid="uid://iqb6h7koghwm" path="res://Assets/Textures/Player/shale-still.tres" id="2_4epgc"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lytr3"]
 bg_color = Color(0, 0, 0, 0.23137255)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_70r3i"]
-bg_color = Color(0.45882353, 0.047058824, 0.047058824, 1)
+bg_color = Color(0.689939, 0.24149421, 0.315474, 1)
 
 [node name="PlayerHealthBar" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_right = -528.0
+offset_bottom = -348.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_4epgc")
@@ -21,9 +23,9 @@ metadata/_edit_lock_ = true
 
 [node name="ProgressBar" type="ProgressBar" parent="."]
 layout_mode = 0
-offset_left = 20.0
-offset_right = 120.0
-offset_bottom = 20.0
+offset_left = 12.0
+offset_right = 112.0
+offset_bottom = 12.0
 theme_override_font_sizes/font_size = 11
 theme_override_styles/background = SubResource("StyleBoxFlat_lytr3")
 theme_override_styles/fill = SubResource("StyleBoxFlat_70r3i")
@@ -32,9 +34,11 @@ show_percentage = false
 
 [node name="CharacterIcon" type="TextureRect" parent="."]
 layout_mode = 0
+offset_left = 1.0
 offset_top = 1.0
-offset_right = 20.0
+offset_right = 21.0
 offset_bottom = 21.0
+scale = Vector2(0.5, 0.5)
 size_flags_horizontal = 4
 size_flags_vertical = 4
 texture = ExtResource("2_4epgc")

--- a/UI/UIPlayerHud/PlayerHud.tscn
+++ b/UI/UIPlayerHud/PlayerHud.tscn
@@ -1,11 +1,11 @@
-[gd_scene load_steps=5 format=3 uid="uid://c0m8rgcsh18sw"]
+[gd_scene load_steps=7 format=3 uid="uid://c0m8rgcsh18sw"]
 
 [ext_resource type="PackedScene" uid="uid://dmb84h028q1aa" path="res://UI/UIPlayerHud/HealthBars.tscn" id="1_1rgaj"]
 [ext_resource type="Script" uid="uid://ctc2mwgudlrdc" path="res://UI/UIPlayerHud/player_hud.gd" id="1_ojyrw"]
 [ext_resource type="PackedScene" uid="uid://c3x3w5b4ecvp6" path="res://UI/UIDialogueBox/DialogueBox.tscn" id="3_cgrjy"]
-[ext_resource type="PackedScene" uid="uid://vw0pfqhb7w5t" path="res://UI/UIPlayerHud/CloneOffscreenIndicator.tscn" id="4_clone_indicator"]
 [ext_resource type="PackedScene" uid="uid://bpis6alqp6fal" path="res://UI/UIPlayerHud/AreaTitleCard.tscn" id="4_area_title"]
-[ext_resource type="PackedScene" uid="uid://c8y52k8tq9z70" path="res://UI/UIPlayerHud/InventoryBar.tscn" id="4_invbar"]
+[ext_resource type="PackedScene" uid="uid://vw0pfqhb7w5t" path="res://UI/UIPlayerHud/CloneOffscreenIndicator.tscn" id="4_clone_indicator"]
+[ext_resource type="PackedScene" uid="uid://c8y52k8tra070" path="res://UI/UIPlayerHud/InventoryBar.tscn" id="4_invbar"]
 
 [node name="PlayerHud" type="Control"]
 layout_mode = 3
@@ -18,6 +18,10 @@ script = ExtResource("1_ojyrw")
 
 [node name="HealthBars" parent="." instance=ExtResource("1_1rgaj")]
 layout_mode = 1
+offset_left = 8.0
+offset_top = 8.0
+offset_right = 8.0
+offset_bottom = 8.0
 
 [node name="InventoryBar" parent="." instance=ExtResource("4_invbar")]
 unique_name_in_owner = true


### PR DESCRIPTION
Changes the health bar visuals to match new player sprites, and adjust colors to better fit the color scheme of the game.

This pull request updates the player HUD and health bar UI components, focusing on visual improvements and better asset management. The most significant changes include adding new texture resources for player and clone icons, updating background and fill colors for health bars, and refining UI element positioning and sizing for a more polished look.

**Asset Management and Icon Updates:**

* Added new `AtlasTexture` resources for the clone (`clone-still.tres`) and player (`shale-still.tres`) icons, and updated scene files to use these new textures instead of direct PNGs. [[1]](diffhunk://#diff-af21ae74b78abf5634fc54e060dd79fd7e6d89fd07b452d84ea7c331ddc577aaR1-R7) [[2]](diffhunk://#diff-0239cff174942a622e28cc2ba7e3aa8c689d57734c5c3869660fe81067bb3facR1-R7) [[3]](diffhunk://#diff-83cd441247cfc6415a84984d3e43f9d739b0e1d9fcc106c8a34261956f7e02fcL4-R28) [[4]](diffhunk://#diff-32a0161aa5d74ec676160585d0aa9afdae3b7c124db538e55143cc16359a9ed8L1-R21)

**Visual and Layout Improvements:**

* Adjusted background and fill colors for health bars and containers to improve visual consistency and appeal. [[1]](diffhunk://#diff-b5b3896bd7dcfc98a3845afdd940384d266bc4892c3150ceb9dd3673abc121dfL11-R11) [[2]](diffhunk://#diff-83cd441247cfc6415a84984d3e43f9d739b0e1d9fcc106c8a34261956f7e02fcL4-R28) [[3]](diffhunk://#diff-32a0161aa5d74ec676160585d0aa9afdae3b7c124db538e55143cc16359a9ed8L1-R21)
* Refined positioning, offsets, and sizing of health bar components and containers for better alignment and spacing in the UI. [[1]](diffhunk://#diff-83cd441247cfc6415a84984d3e43f9d739b0e1d9fcc106c8a34261956f7e02fcL4-R28) [[2]](diffhunk://#diff-83cd441247cfc6415a84984d3e43f9d739b0e1d9fcc106c8a34261956f7e02fcR37-R41) [[3]](diffhunk://#diff-32a0161aa5d74ec676160585d0aa9afdae3b7c124db538e55143cc16359a9ed8L1-R21) [[4]](diffhunk://#diff-b5b3896bd7dcfc98a3845afdd940384d266bc4892c3150ceb9dd3673abc121dfL24-R39) [[5]](diffhunk://#diff-d832688f26e33a7edc5f561fe691428f28b823df35f5b471286758ef4b97a03eR21-R24)
* Updated the `PlayerHud.tscn` to correct resource references and add padding around the health bars. [[1]](diffhunk://#diff-d832688f26e33a7edc5f561fe691428f28b823df35f5b471286758ef4b97a03eL1-R8) [[2]](diffhunk://#diff-d832688f26e33a7edc5f561fe691428f28b823df35f5b471286758ef4b97a03eR21-R24)

These changes collectively enhance the clarity, usability, and aesthetics of the player HUD.