### PR TITLE
feature: Add game speed assist mode

### DIFF
--- a/CrossedDimensions.Tests/Settings/SettingsResourceTest.cs
+++ b/CrossedDimensions.Tests/Settings/SettingsResourceTest.cs
@@ -70,6 +70,44 @@ public class SettingsResourceTest
     }
 
     [Fact]
+    public void AssistGameSpeed_ShouldDefaultToOneHundredPercent()
+    {
+        var settings = new SettingsResource();
+
+        settings.AssistGameSpeed.ShouldBe(1.0f);
+    }
+
+    [Fact]
+    public void AssistGameSpeed_WhenSetBelowRange_ShouldClampToFiftyPercent()
+    {
+        var settings = new SettingsResource();
+
+        settings.AssistGameSpeed = 0.4f;
+
+        settings.AssistGameSpeed.ShouldBe(0.5f);
+    }
+
+    [Fact]
+    public void AssistGameSpeed_WhenSetAboveRange_ShouldClampToOneHundredPercent()
+    {
+        var settings = new SettingsResource();
+
+        settings.AssistGameSpeed = 1.1f;
+
+        settings.AssistGameSpeed.ShouldBe(1.0f);
+    }
+
+    [Fact]
+    public void AssistGameSpeed_WhenSetBetweenSteps_ShouldSnapToNearestTenth()
+    {
+        var settings = new SettingsResource();
+
+        settings.AssistGameSpeed = 0.84f;
+
+        settings.AssistGameSpeed.ShouldBe(0.8f);
+    }
+
+    [Fact]
     public void ToggleFields_WhenSet_ShouldPersistValues()
     {
         var settings = new SettingsResource();
@@ -77,9 +115,11 @@ public class SettingsResourceTest
         settings.ScreenShakeEnabled = false;
         settings.VisualEffectsEnabled = false;
         settings.HdrEnabled = false;
+        settings.AssistGameSpeed = 0.7f;
 
         settings.ScreenShakeEnabled.ShouldBeFalse();
         settings.VisualEffectsEnabled.ShouldBeFalse();
         settings.HdrEnabled.ShouldBeFalse();
+        settings.AssistGameSpeed.ShouldBe(0.7f);
     }
 }

--- a/UI/ScreenOverlayManager.cs
+++ b/UI/ScreenOverlayManager.cs
@@ -115,6 +115,7 @@ public partial class ScreenOverlayManager : CanvasLayer
     private ShaderMaterial _overlayMaterial;
     private float _shakeRemaining;
     private float _currentShakeIntensity;
+    private float _currentFeedbackTimeScaleMultiplier = 1.0f;
     private Camera2D _activeCamera;
     private Vector2 _cameraBasePosition = Vector2.Zero;
     private readonly RandomNumberGenerator _rng = new();
@@ -298,8 +299,17 @@ public partial class ScreenOverlayManager : CanvasLayer
             _muffleHoldRemaining = Mathf.Max(_muffleHoldRemaining, muffleHold);
         }
 
-        // Update timescale (use minimum to handle stacking)
-        Engine.TimeScale = Mathf.Min(Engine.TimeScale, MinTimeScale);
+        // Apply temporary slowdown on top of the user's configured base speed.
+        _currentFeedbackTimeScaleMultiplier = Mathf.Min(_currentFeedbackTimeScaleMultiplier, MinTimeScale);
+        var settingsManager = GetSettingsManager();
+        if (settingsManager is not null)
+        {
+            settingsManager.SetFeedbackTimeScaleMultiplier(_currentFeedbackTimeScaleMultiplier);
+        }
+        else
+        {
+            Engine.TimeScale = _currentFeedbackTimeScaleMultiplier;
+        }
 
         // Update camera shake (refresh if stronger)
         if (IsScreenShakeEnabled() && camera is not null && IsInstanceValid(camera))
@@ -339,14 +349,29 @@ public partial class ScreenOverlayManager : CanvasLayer
         else
         {
             // No timer: snap back immediately
-            Engine.TimeScale = 1f;
+            ResetFeedbackTimeScale();
         }
     }
 
     private void OnFreezeTimerTimeout()
     {
-        Engine.TimeScale = 1f;
+        ResetFeedbackTimeScale();
         _currentShakeIntensity = 0f;
+    }
+
+    private void ResetFeedbackTimeScale()
+    {
+        _currentFeedbackTimeScaleMultiplier = 1.0f;
+
+        var settingsManager = GetSettingsManager();
+        if (settingsManager is not null)
+        {
+            settingsManager.ResetFeedbackTimeScaleMultiplier();
+        }
+        else
+        {
+            Engine.TimeScale = 1.0f;
+        }
     }
 
     private bool IsScreenShakeEnabled()

--- a/UI/UISettings/SettingsAssist.tscn
+++ b/UI/UISettings/SettingsAssist.tscn
@@ -1,0 +1,92 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://UI/UISettings/settings_assist.gd" id="1_5bdh0"]
+[ext_resource type="PackedScene" uid="uid://shi0pllsvrbe" path="res://UI/UIMainMenu/Background.tscn" id="2_e6m7i"]
+[ext_resource type="Theme" uid="uid://b5cn5pegvkqek" path="res://Assets/UITheme.tres" id="3_l4q4a"]
+
+[node name="SettingsAssist" type="Control"]
+process_mode = 3
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("3_l4q4a")
+script = ExtResource("1_5bdh0")
+
+[node name="Background" parent="." instance=ExtResource("2_e6m7i")]
+layout_mode = 0
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 32
+theme_override_constants/margin_top = 32
+theme_override_constants/margin_right = 32
+theme_override_constants/margin_bottom = 32
+
+[node name="AssistSelect" type="HBoxContainer" parent="MarginContainer"]
+custom_minimum_size = Vector2(500, 290)
+layout_mode = 2
+
+[node name="Lables" type="VBoxContainer" parent="MarginContainer/AssistSelect"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Title" type="Label" parent="MarginContainer/AssistSelect/Lables"]
+layout_mode = 2
+theme = ExtResource("3_l4q4a")
+theme_type_variation = &"MenuTitleLabel"
+text = "// Assist"
+
+[node name="MarginContainer2" type="MarginContainer" parent="MarginContainer/AssistSelect/Lables"]
+custom_minimum_size = Vector2(0, 16)
+layout_mode = 2
+
+[node name="GridContainer" type="GridContainer" parent="MarginContainer/AssistSelect/Lables"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/h_separation = 16
+columns = 2
+
+[node name="GameSpeedLabel" type="Label" parent="MarginContainer/AssistSelect/Lables/GridContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Game Speed"
+
+[node name="GameSpeedDropdown" type="OptionButton" parent="MarginContainer/AssistSelect/Lables/GridContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+mouse_default_cursor_shape = 2
+selected = 0
+item_count = 6
+popup/item_0/text = "100%"
+popup/item_0/id = 0
+popup/item_1/text = "90%"
+popup/item_1/id = 1
+popup/item_2/text = "80%"
+popup/item_2/id = 2
+popup/item_3/text = "70%"
+popup/item_3/id = 3
+popup/item_4/text = "60%"
+popup/item_4/id = 4
+popup/item_5/text = "50%"
+popup/item_5/id = 5
+
+[node name="BackButton" type="Button" parent="MarginContainer/AssistSelect/Lables"]
+custom_minimum_size = Vector2(70, 30)
+layout_mode = 2
+size_flags_horizontal = 4
+focus_mode = 0
+mouse_default_cursor_shape = 2
+text = "Back
+"
+
+[connection signal="item_selected" from="MarginContainer/AssistSelect/Lables/GridContainer/GameSpeedDropdown" to="." method="_on_game_speed_dropdown_item_selected"]
+[connection signal="pressed" from="MarginContainer/AssistSelect/Lables/BackButton" to="." method="_on_back_button_pressed"]

--- a/UI/UISettings/SettingsManager.cs
+++ b/UI/UISettings/SettingsManager.cs
@@ -7,6 +7,7 @@ public partial class SettingsManager : Node
 {
     private const string SettingsPath = "user://settings.tres";
     private const string InputBindingsPath = "user://input_bindings.json";
+    private float _feedbackTimeScaleMultiplier = 1.0f;
 
     public SettingsResource Current { get; private set; }
 
@@ -16,6 +17,7 @@ public partial class SettingsManager : Node
         LoadInputBindings();
         ApplyWindowMode(Current.WindowMode);
         ApplyHdr(Current.HdrEnabled);
+        ApplyTimeScale();
     }
 
     public Error Save()
@@ -66,6 +68,35 @@ public partial class SettingsManager : Node
         DisplayServer.WindowSetMode(WindowModeToDisplayServerMode(clampedMode));
     }
 
+    public float GetAssistGameSpeed()
+    {
+        return Current?.AssistGameSpeed ?? 1.0f;
+    }
+
+    public void SetAssistGameSpeed(float assistGameSpeed)
+    {
+        if (Current is null)
+        {
+            return;
+        }
+
+        Current.AssistGameSpeed = assistGameSpeed;
+        ApplyTimeScale();
+        Save();
+    }
+
+    public void SetFeedbackTimeScaleMultiplier(float multiplier)
+    {
+        _feedbackTimeScaleMultiplier = Mathf.Clamp(multiplier, 0.0f, 1.0f);
+        ApplyTimeScale();
+    }
+
+    public void ResetFeedbackTimeScaleMultiplier()
+    {
+        _feedbackTimeScaleMultiplier = 1.0f;
+        ApplyTimeScale();
+    }
+
     public bool IsScreenShakeEnabled()
     {
         return Current?.ScreenShakeEnabled ?? true;
@@ -83,6 +114,11 @@ public partial class SettingsManager : Node
         {
             GetTree().Root.UseHdr2D = enabled;
         }
+    }
+
+    public void ApplyTimeScale()
+    {
+        Engine.TimeScale = GetAssistGameSpeed() * _feedbackTimeScaleMultiplier;
     }
 
     private void LoadOrCreateSettings()

--- a/UI/UISettings/SettingsResource.cs
+++ b/UI/UISettings/SettingsResource.cs
@@ -9,6 +9,7 @@ namespace CrossedDimensions.UI.UISettings;
 public partial class SettingsResource : Resource
 {
     private int _windowMode;
+    private float _assistGameSpeed = 1.0f;
 
     /// <summary>
     /// Display mode setting index.
@@ -38,4 +39,19 @@ public partial class SettingsResource : Resource
     /// </summary>
     [Export]
     public bool HdrEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Base gameplay speed multiplier used for assist mode.
+    /// Stored as discrete 10% steps from 50% to 100%.
+    /// </summary>
+    [Export]
+    public float AssistGameSpeed
+    {
+        get => _assistGameSpeed;
+        set
+        {
+            float snappedValue = Mathf.Round(value * 10.0f) / 10.0f;
+            _assistGameSpeed = Mathf.Clamp(snappedValue, 0.5f, 1.0f);
+        }
+    }
 }

--- a/UI/UISettings/SettingsSelect.tscn
+++ b/UI/UISettings/SettingsSelect.tscn
@@ -68,6 +68,13 @@ focus_mode = 0
 mouse_default_cursor_shape = 2
 text = "Keybinds"
 
+[node name="AssistButton" type="Button" parent="MarginContainer/VBoxContainer/SettingSelect"]
+layout_mode = 2
+size_flags_horizontal = 4
+focus_mode = 0
+mouse_default_cursor_shape = 2
+text = "Assist"
+
 [node name="BackButton" type="Button" parent="MarginContainer/VBoxContainer/SettingSelect"]
 layout_mode = 2
 size_flags_horizontal = 4
@@ -85,4 +92,5 @@ layout_mode = 2
 [connection signal="pressed" from="MarginContainer/VBoxContainer/SettingSelect/AudioButton" to="." method="_on_audio_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/SettingSelect/VideoButton" to="." method="_on_video_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/SettingSelect/KeybindsButton" to="." method="_on_keybinds_button_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/SettingSelect/AssistButton" to="." method="_on_assist_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/SettingSelect/BackButton" to="." method="_on_back_button_pressed"]

--- a/UI/UISettings/settings_assist.gd
+++ b/UI/UISettings/settings_assist.gd
@@ -1,0 +1,36 @@
+class_name SettingsAssist
+extends Control
+
+const GAME_SPEED_OPTIONS := [1.0, 0.9, 0.8, 0.7, 0.6, 0.5]
+
+@onready var game_speed_dropdown: OptionButton = %GameSpeedDropdown
+var settings_manager = null
+
+func _ready() -> void:
+	settings_manager = get_node_or_null("/root/SettingsManager")
+
+	if not _has_current_settings():
+		return
+
+	var current_speed: float = settings_manager.GetAssistGameSpeed()
+	var selected_index := GAME_SPEED_OPTIONS.find(current_speed)
+	if selected_index == -1:
+		selected_index = 0
+	game_speed_dropdown.select(selected_index)
+
+func _on_game_speed_dropdown_item_selected(index: int) -> void:
+	if not _has_current_settings():
+		return
+	if index < 0 or index >= GAME_SPEED_OPTIONS.size():
+		return
+	settings_manager.SetAssistGameSpeed(GAME_SPEED_OPTIONS[index])
+
+func _on_back_button_pressed() -> void:
+	hide()
+
+func _has_current_settings() -> bool:
+	if settings_manager == null:
+		settings_manager = get_node_or_null("/root/SettingsManager")
+	if settings_manager == null:
+		return false
+	return settings_manager.Current != null

--- a/UI/UISettings/settings_assist.gd.uid
+++ b/UI/UISettings/settings_assist.gd.uid
@@ -1,0 +1,1 @@
+uid://un254dhpuyty

--- a/UI/UISettings/settings_select.gd
+++ b/UI/UISettings/settings_select.gd
@@ -8,6 +8,7 @@ var settings_manager = null
 var setting_audio
 var settings_video
 var settings_keybinds
+var settings_assist
 var canvas_layer
 var submenus = []
 var settings_is_open = false
@@ -15,6 +16,7 @@ var settings_is_open = false
 const SettingsAudioScene := preload("res://UI/UISettings/SettingsAudio.tscn")
 const SettingsVideoScene := preload("res://UI/UISettings/SettingsVideo.tscn")
 const SettingsKeybindsScene := preload("res://UI/UISettings/SettingsKeybindsNew.tscn")
+const SettingsAssistScene := preload("res://UI/UISettings/SettingsAssist.tscn")
 
 func _ready() -> void:
 	settings_manager = get_node_or_null("/root/SettingsManager")
@@ -27,8 +29,9 @@ func open_settings() -> void:
 	setting_audio = SettingsAudioScene.instantiate()
 	settings_video = SettingsVideoScene.instantiate()
 	settings_keybinds = SettingsKeybindsScene.instantiate()
+	settings_assist = SettingsAssistScene.instantiate()
 	canvas_layer = CanvasLayer.new()
-	submenus = [setting_audio, settings_video, settings_keybinds]
+	submenus = [setting_audio, settings_video, settings_keybinds, settings_assist]
 	
 	canvas_layer.layer = 10
 	for submenu in submenus:
@@ -48,6 +51,10 @@ func _on_video_button_pressed() -> void:
 func _on_keybinds_button_pressed() -> void:
 	if settings_is_open:
 		settings_keybinds.show()
+
+func _on_assist_button_pressed() -> void:
+	if settings_is_open:
+		settings_assist.show()
 
 func _on_back_button_pressed() -> void:
 	close_settings()


### PR DESCRIPTION
Adds an accessibility option to lower difficulty by slowing the game down, similar to Celeste's assist mode.

---

This pull request introduces a new "Assist" settings menu that allows players to adjust the base gameplay speed for accessibility, and refactors how temporary game speed changes (like slowdowns for feedback effects) interact with this setting. The main changes include adding an "Assist" button and menu, implementing persistent and clamped assist game speed settings, and ensuring feedback slowdowns stack correctly with the user's chosen speed.

**Assist Gameplay Speed Feature**

* Added a new "Assist" settings menu (`SettingsAssist.tscn` and `settings_assist.gd`) with a dropdown to select game speed from 50% to 100% in 10% steps. The menu is accessible from the main settings via a new "Assist" button. [[1]](diffhunk://#diff-de0d24e1781283b103780d4180eea1fdbc964c8e9dbfeb6258549f3c1c6bbf3aR1-R92) [[2]](diffhunk://#diff-58a93e6d5cc379fca89c028ab0193124622c443fcc78e23341c21400ffafca9cR1-R36) [[3]](diffhunk://#diff-badd546bd1dfac3ecf0572e059e1800a8e2ce9c7c2e138bd3796e38c82311162R71-R77) [[4]](diffhunk://#diff-badd546bd1dfac3ecf0572e059e1800a8e2ce9c7c2e138bd3796e38c82311162R95) [[5]](diffhunk://#diff-049a37a41fed5cd1952c9170d9024ddda710144bc693c53d81e8b49b03873151R11-R19) [[6]](diffhunk://#diff-049a37a41fed5cd1952c9170d9024ddda710144bc693c53d81e8b49b03873151R32-R34) [[7]](diffhunk://#diff-049a37a41fed5cd1952c9170d9024ddda710144bc693c53d81e8b49b03873151R55-R58)
* Introduced a new `AssistGameSpeed` property in `SettingsResource`, which is clamped between 0.5 and 1.0 and snaps to the nearest 0.1. Includes tests for default, clamping, and snapping behavior. [[1]](diffhunk://#diff-886d208863dfae4eef8b4e8026fb12b0be4d516db94c36bf51d1e3894ef01240R12) [[2]](diffhunk://#diff-886d208863dfae4eef8b4e8026fb12b0be4d516db94c36bf51d1e3894ef01240R42-R56) [[3]](diffhunk://#diff-e014755a41bd1fb203302b9e58e07bd3ba04b185b2dace1666194d6075d4b0fbR72-R109) [[4]](diffhunk://#diff-e014755a41bd1fb203302b9e58e07bd3ba04b185b2dace1666194d6075d4b0fbR118-R123)

**Game Speed Application and Feedback Refactor**

* Refactored how temporary slowdowns (e.g., for hitstop or feedback) are applied: the engine timescale now multiplies the user's assist speed by any feedback multiplier, ensuring accessibility settings are respected during slowdowns. [[1]](diffhunk://#diff-291e2634eb15c277018df7c3ff6e9e19c9b764ffa468801c843577c6a928a294L301-R312) [[2]](diffhunk://#diff-291e2634eb15c277018df7c3ff6e9e19c9b764ffa468801c843577c6a928a294L342-R376) [[3]](diffhunk://#diff-291e2634eb15c277018df7c3ff6e9e19c9b764ffa468801c843577c6a928a294R118) [[4]](diffhunk://#diff-9ccee92f6155d889942c35a4074794c9d812f29666dfb704866c9cce07c7429cR10) [[5]](diffhunk://#diff-9ccee92f6155d889942c35a4074794c9d812f29666dfb704866c9cce07c7429cR20) [[6]](diffhunk://#diff-9ccee92f6155d889942c35a4074794c9d812f29666dfb704866c9cce07c7429cR71-R99) [[7]](diffhunk://#diff-9ccee92f6155d889942c35a4074794c9d812f29666dfb704866c9cce07c7429cR119-R123)

**Other**

* Added a unique identifier for the new `settings_assist.gd` script.

These changes improve accessibility by letting users set a persistent gameplay speed, ensure all slowdowns stack correctly, and provide a clear and testable implementation.