### PR TITLE
feature: Add ending screen

### DIFF
--- a/Entities/Bosses/FileCypher/FileCypherBoss.tscn
+++ b/Entities/Bosses/FileCypher/FileCypherBoss.tscn
@@ -19,7 +19,7 @@
 [ext_resource type="Script" uid="uid://bks6bqyscxh45" path="res://Components/HealthComponent.cs" id="17"]
 [ext_resource type="Script" uid="uid://dgoul8uu33gsx" path="res://Characters/Controllers/EnemyController.cs" id="18"]
 [ext_resource type="Script" uid="uid://cefu8colkgdrs" path="res://Entities/Enemies/EnemyComponent.cs" id="19"]
-[ext_resource type="Script" uid="uid://b4n02rdxirgry" path="res://Entities/Enemies/queue_free_death_handler.gd" id="20"]
+[ext_resource type="Script" path="res://Entities/Bosses/FileCypher/FileCypherDeathHandler.cs" id="20"]
 [ext_resource type="Texture2D" uid="uid://coynjpceuh1jk" path="res://Assets/Textures/circle-16.png" id="21"]
 [ext_resource type="PackedScene" uid="uid://c1omxkcbb4038" path="res://Entities/Bosses/FileCypher/SoftHomingBullet.tscn" id="22"]
 [ext_resource type="PackedScene" uid="uid://cthp22yntr7xa" path="res://Entities/Bosses/FileCypher/StripeMissile.tscn" id="23"]

--- a/Entities/Bosses/FileCypher/FileCypherDeathHandler.cs
+++ b/Entities/Bosses/FileCypher/FileCypherDeathHandler.cs
@@ -1,0 +1,28 @@
+using CrossedDimensions.Saves;
+using Godot;
+
+namespace CrossedDimensions.Entities.Bosses.FileCypher;
+
+public partial class FileCypherDeathHandler : Node
+{
+    private const string EndingScreenScenePath = "res://UI/UIEndingScreen/EndingScreen.tscn";
+
+    private bool _transitionScheduled;
+
+    private void _on_health_component_health_changed(int oldHealth)
+    {
+        if (_transitionScheduled)
+        {
+            return;
+        }
+
+        var healthComponent = GetParent<Components.HealthComponent>();
+        if (healthComponent.IsAlive)
+        {
+            return;
+        }
+
+        _transitionScheduled = true;
+        SceneManager.Instance?.LoadSceneSync(EndingScreenScenePath, true);
+    }
+}

--- a/Entities/Bosses/FileCypher/FileCypherDeathHandler.cs.uid
+++ b/Entities/Bosses/FileCypher/FileCypherDeathHandler.cs.uid
@@ -1,0 +1,1 @@
+uid://cutgd0enagdyi

--- a/UI/UIEndingScreen/EndingScreen.cs
+++ b/UI/UIEndingScreen/EndingScreen.cs
@@ -1,0 +1,113 @@
+using System;
+using CrossedDimensions.Audio;
+using CrossedDimensions.Saves;
+using Godot;
+
+namespace CrossedDimensions.UI.UIEndingScreen;
+
+public partial class EndingScreen : Control
+{
+    private const string MainMenuScenePath = "res://UI/UIMainMenu/MainMenu.tscn";
+
+    private AnimationPlayer _animationPlayer;
+    private SceneManager _sceneManager;
+    private VBoxContainer[] _stanzaContainers;
+    private Button[] _continueButtons;
+    private int _currentStanzaIndex;
+
+    public override void _Ready()
+    {
+        _animationPlayer = GetNode<AnimationPlayer>("AnimationPlayer");
+        _sceneManager = GetNode<SceneManager>("/root/SceneManager");
+        _stanzaContainers =
+        [
+            GetNode<VBoxContainer>("MarginContainer/CenterContainer/EndingMenu/Stanza1"),
+            GetNode<VBoxContainer>("MarginContainer/CenterContainer/EndingMenu/Stanza2"),
+            GetNode<VBoxContainer>("MarginContainer/CenterContainer/EndingMenu/Stanza3"),
+            GetNode<VBoxContainer>("MarginContainer/CenterContainer/EndingMenu/Stanza4")
+        ];
+        _continueButtons =
+        [
+            GetNode<Button>("MarginContainer/CenterContainer/EndingMenu/Stanza1/ContinueButton"),
+            GetNode<Button>("MarginContainer/CenterContainer/EndingMenu/Stanza2/ContinueButton"),
+            GetNode<Button>("MarginContainer/CenterContainer/EndingMenu/Stanza3/ContinueButton"),
+            GetNode<Button>("MarginContainer/CenterContainer/EndingMenu/Stanza4/ContinueButton")
+        ];
+
+        StopAllMusic();
+
+        for (int index = 0; index < _continueButtons.Length; index++)
+        {
+            int stanzaIndex = index;
+            _continueButtons[index].Pressed += () => OnContinuePressed(stanzaIndex);
+        }
+
+        _animationPlayer.AnimationFinished += OnAnimationFinished;
+
+        ShowStanza(0);
+    }
+
+    private void ShowStanza(int index)
+    {
+        _currentStanzaIndex = index;
+
+        for (int stanzaIndex = 0; stanzaIndex < _stanzaContainers.Length; stanzaIndex++)
+        {
+            ResetStanza(_stanzaContainers[stanzaIndex], stanzaIndex == index);
+        }
+
+        _animationPlayer.Play(AnimationName(index));
+    }
+
+    private static void ResetStanza(VBoxContainer stanza, bool isVisible)
+    {
+        stanza.Visible = isVisible;
+
+        foreach (Node child in stanza.GetChildren())
+        {
+            if (child is CanvasItem canvasItem)
+            {
+                canvasItem.Modulate = new Color(1, 1, 1, 0);
+            }
+
+            if (child is Button button)
+            {
+                button.Disabled = true;
+            }
+        }
+    }
+
+    private static string AnimationName(int index)
+    {
+        return $"stanza_{index}";
+    }
+
+    private void OnAnimationFinished(StringName animationName)
+    {
+        if (animationName != AnimationName(_currentStanzaIndex))
+        {
+            return;
+        }
+
+        _continueButtons[_currentStanzaIndex].GrabFocus();
+    }
+
+    private void OnContinuePressed(int index)
+    {
+        if (index < _stanzaContainers.Length - 1)
+        {
+            ShowStanza(index + 1);
+            return;
+        }
+
+        _sceneManager.LoadSceneSync(MainMenuScenePath, true);
+    }
+
+    private static void StopAllMusic()
+    {
+        foreach (MusicPriority priority in Enum.GetValues<MusicPriority>())
+        {
+            MusicManager.Instance?.StopTrack(priority);
+        }
+    }
+}

--- a/UI/UIEndingScreen/EndingScreen.cs.uid
+++ b/UI/UIEndingScreen/EndingScreen.cs.uid
@@ -1,0 +1,1 @@
+uid://c6jtgdy2gp34d

--- a/UI/UIEndingScreen/EndingScreen.tscn
+++ b/UI/UIEndingScreen/EndingScreen.tscn
@@ -1,0 +1,444 @@
+[gd_scene load_steps=8 format=3 uid="uid://dm0ncjub8k8yh"]
+
+[ext_resource type="Script" uid="uid://c6jtgdy2gp34d" path="res://UI/UIEndingScreen/EndingScreen.cs" id="1_wd3s7"]
+[ext_resource type="Theme" uid="uid://b5cn5pegvkqek" path="res://Assets/UITheme.tres" id="2_q0knf"]
+
+[sub_resource type="Animation" id="Animation_stanza1"]
+resource_name = "stanza_0"
+length = 8.000025
+step = 0.25
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza1/Line1:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 1.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza1/Line2:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 3, 3.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza1/Line3:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 5, 5.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza1/ContinueButton:modulate")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 7, 7.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza1/ContinueButton:disabled")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 7.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+
+[sub_resource type="Animation" id="Animation_stanza2"]
+resource_name = "stanza_1"
+length = 8.000025
+step = 0.25
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza2/Line1:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 1.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza2/Line2:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 3, 3.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza2/Line3:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 5, 5.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza2/ContinueButton:modulate")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 7, 7.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza2/ContinueButton:disabled")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 7.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+
+[sub_resource type="Animation" id="Animation_stanza3"]
+resource_name = "stanza_2"
+length = 8.000025
+step = 0.25
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza3/Line1:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 1.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza3/Line2:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 3, 3.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza3/Line3:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 5, 5.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza3/ContinueButton:modulate")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 7, 7.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza3/ContinueButton:disabled")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 7.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+
+[sub_resource type="Animation" id="Animation_stanza4"]
+resource_name = "stanza_3"
+length = 2.000025
+step = 0.25
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza4/Line1:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1, 1.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza4/Line2:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 1, 1.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza4/Line3:modulate")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 1, 1.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza4/ContinueButton:modulate")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 1, 1.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+tracks/4/type = "value"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("MarginContainer/CenterContainer/EndingMenu/Stanza4/ContinueButton:disabled")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"times": PackedFloat32Array(0, 1.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_wd3s7"]
+_data = {
+&"stanza_0": SubResource("Animation_stanza1"),
+&"stanza_1": SubResource("Animation_stanza2"),
+&"stanza_2": SubResource("Animation_stanza3"),
+&"stanza_3": SubResource("Animation_stanza4")
+}
+
+[node name="EndingScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("2_q0knf")
+script = ExtResource("1_wd3s7")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 1)
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 40
+theme_override_constants/margin_top = 40
+theme_override_constants/margin_right = 40
+theme_override_constants/margin_bottom = 40
+
+[node name="CenterContainer" type="CenterContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="EndingMenu" type="VBoxContainer" parent="MarginContainer/CenterContainer"]
+custom_minimum_size = Vector2(560, 0)
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Stanza1" type="VBoxContainer" parent="MarginContainer/CenterContainer/EndingMenu"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Line1" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza1"]
+layout_mode = 2
+text = "The failures of humanity keep accumulating."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Line2" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza1"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+text = "The world is a place where even those with good intentions can cause mass devastation."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Line3" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza1"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+text = "You may be witness to such things right now."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="ContinueButton" type="Button" parent="MarginContainer/CenterContainer/EndingMenu/Stanza1"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+mouse_default_cursor_shape = 2
+disabled = true
+text = "Continue"
+
+[node name="Stanza2" type="VBoxContainer" parent="MarginContainer/CenterContainer/EndingMenu"]
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Line1" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza2"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+text = "There isn't a happy ending to the world."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Line2" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza2"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+text = "Reality isn't a fairy tale."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Line3" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza2"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+text = "Satisfaction in the tale woven by events isn't a goal it optimizes for."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="ContinueButton" type="Button" parent="MarginContainer/CenterContainer/EndingMenu/Stanza2"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+mouse_default_cursor_shape = 2
+disabled = true
+text = "Continue"
+
+[node name="Stanza3" type="VBoxContainer" parent="MarginContainer/CenterContainer/EndingMenu"]
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Line1" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza3"]
+layout_mode = 2
+text = "Take satisfaction in what you do to make it better."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Line2" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza3"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+text = "Take satisfaction in solving the problems of the day."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Line3" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza3"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+text = "Don't let the world's power structures prevent you from reaching to the next dawn."
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="ContinueButton" type="Button" parent="MarginContainer/CenterContainer/EndingMenu/Stanza3"]
+modulate = Color(1, 1, 1, 0)
+layout_mode = 2
+size_flags_horizontal = 4
+mouse_default_cursor_shape = 2
+disabled = true
+text = "Continue"
+
+[node name="Stanza4" type="VBoxContainer" parent="MarginContainer/CenterContainer/EndingMenu"]
+visible = false
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="Line1" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza4"]
+layout_mode = 2
+text = "~ Thank you for playing ~"
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Line2" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza4"]
+layout_mode = 2
+text = "University of Nevada, Reno"
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="Line3" type="Label" parent="MarginContainer/CenterContainer/EndingMenu/Stanza4"]
+layout_mode = 2
+text = "Innovation Day Spring 2026"
+horizontal_alignment = 1
+autowrap_mode = 2
+
+[node name="ContinueButton" type="Button" parent="MarginContainer/CenterContainer/EndingMenu/Stanza4"]
+layout_mode = 2
+size_flags_horizontal = 4
+mouse_default_cursor_shape = 2
+text = "Continue"
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+&"": SubResource("AnimationLibrary_wd3s7")
+}


### PR DESCRIPTION
Adds an ending screen when File Cypher dies.

---

This pull request introduces the new ending screen sequence that is triggered upon the defeat of the FileCypher boss, and refactors the death handling logic to support this feature. The main changes include the addition of a new C# death handler for the boss, a new interactive ending screen, and updates to resource references to use the new handler.

**Boss Defeat and Ending Sequence Integration:**

* Replaced the old GDScript-based death handler with a new C# implementation, `FileCypherDeathHandler`, which detects when the FileCypher boss dies and synchronously loads the new ending screen scene (`EndingScreen.tscn`). (`Entities/Bosses/FileCypher/FileCypherBoss.tscn`, `Entities/Bosses/FileCypher/FileCypherDeathHandler.cs`, [[1]](diffhunk://#diff-ef889383f3c6b90928a2608b35c4192df3e9c7a07d28cb577fd414b9af02198cL22-R22) [[2]](diffhunk://#diff-485d471ca68014bb578c7fb3eaf100875658ac5078c10cb6277673c23a5f1205R1-R28) [[3]](diffhunk://#diff-fc62fef36d83a05d171c17add886621fb93f5cab5f778a1579a481d7e68f79aaR1)

**Ending Screen Implementation:**

* Added a new `EndingScreen` class (`EndingScreen.cs`) that manages a multi-stanza ending sequence with animated transitions, continue buttons, and a return to the main menu. It also ensures all background music is stopped when the ending screen appears. (`UI/UIEndingScreen/EndingScreen.cs`, [[1]](diffhunk://#diff-88974fbe9c05cff9db982d110a2fa5e8a1ebb875911170991cf458092b40e617R1-R113) [[2]](diffhunk://#diff-9091fab3250779a5e5bf36712d8791198eeb358c0704564b45deb3ecebef86b2R1)