### PR TITLE
feature: Add merge player area

### DIFF
--- a/BoundingBoxes/MergePlayerArea.cs
+++ b/BoundingBoxes/MergePlayerArea.cs
@@ -1,0 +1,35 @@
+using Godot;
+
+namespace CrossedDimensions.BoundingBoxes;
+
+[GlobalClass]
+public partial class MergePlayerArea : Area2D
+{
+    public override void _Ready()
+    {
+        BodyEntered += OnBodyEntered;
+    }
+
+    public override void _Notification(int what)
+    {
+        if (what == NotificationPredelete)
+        {
+            BodyEntered -= OnBodyEntered;
+        }
+    }
+
+    private void OnBodyEntered(Node body)
+    {
+        if (body is not Characters.Character character)
+        {
+            return;
+        }
+
+        if (!character.IsInGroup("Player"))
+        {
+            return;
+        }
+
+        character.Cloneable?.Merge();
+    }
+}

--- a/BoundingBoxes/MergePlayerArea.cs.uid
+++ b/BoundingBoxes/MergePlayerArea.cs.uid
@@ -1,0 +1,1 @@
+uid://u7b9m5r6v1k2q

--- a/CrossedDimensions.Tests/BoundingBoxes/MergePlayerAreaTest.cs
+++ b/CrossedDimensions.Tests/BoundingBoxes/MergePlayerAreaTest.cs
@@ -1,0 +1,77 @@
+using CrossedDimensions.BoundingBoxes;
+using CrossedDimensions.Characters;
+using Godot;
+using System;
+
+namespace CrossedDimensions.Tests.BoundingBoxes;
+
+[Collection("GodotHeadless")]
+public sealed class MergePlayerAreaTest : IDisposable
+{
+    private const string CharacterScenePath = "res://Characters/Character.tscn";
+
+    private readonly GodotHeadlessFixedFpsFixture _godot;
+    private readonly Node _sceneRoot;
+    private readonly Character _player;
+    private readonly MergePlayerArea _mergeArea;
+
+    public MergePlayerAreaTest(GodotHeadlessFixedFpsFixture godot)
+    {
+        _godot = godot;
+        _sceneRoot = new Node { Name = "merge_player_area_test_root" };
+        _godot.Tree.Root.AddChild(_sceneRoot);
+
+        _player = ResourceLoader
+            .Load<PackedScene>(CharacterScenePath)
+            .Instantiate<Character>();
+        _sceneRoot.AddChild(_player);
+
+        _mergeArea = new MergePlayerArea { Name = "merge_player_area" };
+        _sceneRoot.AddChild(_mergeArea);
+
+        _godot.GodotInstance.Iteration(2);
+    }
+
+    public void Dispose()
+    {
+        _sceneRoot?.QueueFree();
+    }
+
+    [Fact]
+    public void MergePlayerArea_WhenOriginalPlayerEnters_MergesClone()
+    {
+        var clone = _player.Cloneable.Split();
+        clone.ShouldNotBeNull();
+
+        _mergeArea.EmitSignal(Area2D.SignalName.BodyEntered, _player);
+
+        _player.Cloneable.Clone.ShouldBeNull();
+        clone.IsQueuedForDeletion().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MergePlayerArea_WhenClonePlayerEnters_MergesClone()
+    {
+        var clone = _player.Cloneable.Split();
+        clone.ShouldNotBeNull();
+
+        _mergeArea.EmitSignal(Area2D.SignalName.BodyEntered, clone);
+
+        _player.Cloneable.Clone.ShouldBeNull();
+        clone.IsQueuedForDeletion().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MergePlayerArea_WhenNonPlayerCharacterEnters_DoesNotMerge()
+    {
+        _player.RemoveFromGroup("Player");
+        var clone = _player.Cloneable.Split();
+        clone.ShouldNotBeNull();
+
+        _mergeArea.EmitSignal(Area2D.SignalName.BodyEntered, _player);
+        _godot.GodotInstance.Iteration(1);
+
+        _player.Cloneable.Clone.ShouldBe(clone);
+        clone.IsQueuedForDeletion().ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
Adds a trigger to automatically merge the player. It calls Merge on the triggering player's CloneableComponent which will merge the clone whether it is invoking the player's or the clone's cloneable

---

This pull request introduces a new `MergePlayerArea` feature, which allows player characters to merge their clones when entering a designated area. It includes the implementation of the area, its registration with the engine, and comprehensive automated tests to verify correct behavior.

### New Feature: MergePlayerArea

* Added `MergePlayerArea` class in `BoundingBoxes/MergePlayerArea.cs`, which listens for bodies entering the area and merges the player's clone if a player character enters.
* Registered the new area with the engine by adding a unique identifier in `BoundingBoxes/MergePlayerArea.cs.uid`.

### Testing

* Added `MergePlayerAreaTest` in `CrossedDimensions.Tests/BoundingBoxes/MergePlayerAreaTest.cs`, providing unit tests to ensure that the merge logic works for both original and clone players, and does not trigger for non-player characters.