### PR TITLE
chore: Remove debug print statements

### DIFF
--- a/Entities/Bosses/Drill/Drilling.cs
+++ b/Entities/Bosses/Drill/Drilling.cs
@@ -178,8 +178,6 @@ public partial class Drilling : State
     private void VentDied()
     {
 
-        GD.Print("Vent Died!!");
-
         _currentVentsDead += 1;
 
         if (_currentVentsDead == Vents.Count)

--- a/Entities/Bosses/Drill/Drop.cs
+++ b/Entities/Bosses/Drill/Drop.cs
@@ -20,8 +20,6 @@ public partial class Drop : State
     {
         _drillBit = Context as Character;
 
-        GD.Print("Drop!");
-
         return base.Enter(previousState);
     }
 

--- a/Entities/Bosses/Drill/Frozen.cs
+++ b/Entities/Bosses/Drill/Frozen.cs
@@ -72,8 +72,6 @@ public partial class Frozen : State
     {
         var curHealth = Health.CurrentHealth;
 
-        GD.Print("Current vent health: ", curHealth);
-
         if (curHealth <= 0)
         {
             StateMachine parent = GetParent<StateMachine>();

--- a/Entities/Bosses/Drill/SideToSide.cs
+++ b/Entities/Bosses/Drill/SideToSide.cs
@@ -24,8 +24,6 @@ public partial class SideToSide : State
     {
         _drillBit = Context as Character;
 
-        GD.Print("Side to side!");
-
         return base.Enter(previousState);
     }
 

--- a/Entities/Bosses/Drill/Up.cs
+++ b/Entities/Bosses/Drill/Up.cs
@@ -31,8 +31,6 @@ public partial class Up : State
             collision.Disabled = true;
         }
 
-        GD.Print("Up!");
-
         return base.Enter(previousState);
     }
 

--- a/Entities/Bosses/FileCypher/CypherSequencer.cs
+++ b/Entities/Bosses/FileCypher/CypherSequencer.cs
@@ -124,7 +124,6 @@ public partial class CypherSequencer : State
         }
 
         var nextAttack = GetNextAttackName();
-        GD.Print($"[FileCypher] Starting attack: {nextAttack}");
         _waitingForAttackToFinish = true;
         _attacks.ChangeState(nextAttack);
 
@@ -242,7 +241,6 @@ public partial class CypherSequencer : State
 
     private void OnAttackFinished()
     {
-        GD.Print("[FileCypher] Attack finished.");
         _queuedAttackFinished = true;
     }
 

--- a/Entities/Bosses/Siracus/Attacking.cs
+++ b/Entities/Bosses/Siracus/Attacking.cs
@@ -61,8 +61,6 @@ public partial class Attacking : State
                     attackStateMachine.ChangeState(_pickedAttack);
                 }
 
-                GD.Print("Attack picked: ", _pickedAttack.Name);
-
                 // Assign signal to exit function
 
                 _attackIdle.AttackHasFinished += AttackFinished;

--- a/Entities/Bosses/Siracus/Change.cs
+++ b/Entities/Bosses/Siracus/Change.cs
@@ -78,8 +78,6 @@ public partial class Change : State
     {
         if (_animSprite.Animation == "Emerge")
         {
-            GD.Print("Hi!");
-
             _animSprite.Visible = false;
             SetCollisionActive(false);
             _hiding = true;

--- a/Entities/Bosses/Siracus/Critters.cs
+++ b/Entities/Bosses/Siracus/Critters.cs
@@ -31,8 +31,6 @@ public partial class Critters : State
 
     public override State Enter(State previousState)
     {
-        GD.Print("Attacking");
-
         _siracus = Context as Character;
         if (_siracus == null) { GD.PrintErr("[Critters] Context is not a Character!"); return base.Enter(previousState); }
 
@@ -48,8 +46,6 @@ public partial class Critters : State
         curTime = 0.0f;
 
         rng = new RandomNumberGenerator();
-
-        GD.Print("[Critters] Ready. Will spawn ", maxCritters, " critters every ", waitTimeMax, "s from ", critterSpawnPoint?.GlobalPosition);
 
         return base.Enter(previousState);
     }
@@ -73,16 +69,10 @@ public partial class Critters : State
 
             critterInstance.GlobalPosition = critterSpawnPoint.GlobalPosition;
 
-            GD.Print(_siracus.GlobalPosition);
-            GD.Print(critterInstance.GlobalPosition);
-
             curCritters++;
-
-            GD.Print("[Critters] Spawned critter ", curCritters, "/", maxCritters, " at ", critterInstance.GlobalPosition, " with velocity (", critterInstance.Velocity, ")");
 
             if (curCritters >= maxCritters)
             {
-                GD.Print("[Critters] All critters spawned — transitioning to AttackIdle.");
                 var stateMachine = GetParent() as StateMachine;
                 if (stateMachine == null) { GD.PrintErr("[Critters] Parent is not a StateMachine!"); return base.Process(delta); }
                 State attackIdle = stateMachine.FindChild("AttackIdle") as State;

--- a/Entities/Bosses/Siracus/Shotgun.cs
+++ b/Entities/Bosses/Siracus/Shotgun.cs
@@ -40,8 +40,6 @@ public partial class Shotgun : State
 
     public override State Enter(State previousState)
     {
-        GD.Print("Attacking");
-
         _siracus = Context as Character;
 
         _player = GetTree().GetFirstNodeInGroup("Player") as Character;

--- a/Entities/Bosses/Siracus/Slash.cs
+++ b/Entities/Bosses/Siracus/Slash.cs
@@ -13,8 +13,6 @@ public partial class Slash : State
 
     public override State Enter(State previousState)
     {
-        GD.Print("Attacking");
-
         animPlay.AnimationFinished += AnimationFinished;
 
         if (animPlay.HasAnimation("Slash"))

--- a/Entities/Bosses/Siracus/Tail.cs
+++ b/Entities/Bosses/Siracus/Tail.cs
@@ -41,8 +41,6 @@ public partial class Tail : State
     {
         // Enter hole, set default vars
 
-        GD.Print("Attacking");
-
         _siracus = Context as Character;
         _player = GetTree().GetFirstNodeInGroup("Player") as Character;
 
@@ -119,8 +117,6 @@ public partial class Tail : State
     {
         bool isReversedEmerge = _animSprite.Animation == "Emerge";
         if (!isReversedEmerge) return;
-
-        GD.Print("Hi!");
 
         _animSprite.Visible = false;
         SetCollisionActive(false);

--- a/Entities/Enemies/Bat/BatSwooping.cs
+++ b/Entities/Enemies/Bat/BatSwooping.cs
@@ -59,8 +59,6 @@ public partial class BatSwooping : State
                     _sprite.FlipH = false;
                 }
 
-                GD.Print(goingRight);
-
                 pastRight = goingRight;
             }
 

--- a/Environment/Cutscene/DialoguePlayer.cs
+++ b/Environment/Cutscene/DialoguePlayer.cs
@@ -64,7 +64,6 @@ public partial class DialoguePlayer : Node
 
     public void LoadFrame(DialogueFrame frame)
     {
-        GD.Print("Loading frame", frame);
         CurrentFrame = frame;
         targetText = CurrentFrame.Text;
         displayText = "";
@@ -149,18 +148,15 @@ public partial class DialoguePlayer : Node
 
     public virtual void Advance()
     {
-        GD.Print($"Page advance detected");
         EmitSignal(SignalName.Advancing);
     }
 
     public virtual void Load()
     {
-        GD.Print($"Load next frame detected!");
         EmitSignal(SignalName.Loading);
     }
     public virtual void End()
     {
-        GD.Print($"End dialogue detected");
         EmitSignal(SignalName.Ending);
     }
 

--- a/States/Characters/CharacterMergeHoldState.cs
+++ b/States/Characters/CharacterMergeHoldState.cs
@@ -47,8 +47,6 @@ public sealed partial class CharacterMergeHoldState : CharacterState
                 _healAccumulator -= wholeHeal;
             }
 
-            GD.Print($"Healing: {CharacterContext.Health.CurrentHealth}, Healing Pool: {cloneable.HealingPool}");
-
             if (cloneable.HealingPool <= 0)
             {
                 return IdleState;

--- a/UI/UIDialogueBox/DialogueBox.cs
+++ b/UI/UIDialogueBox/DialogueBox.cs
@@ -48,7 +48,6 @@ public partial class DialogueBox : Control
             //revael one additonal chareacter unless dialougeIsDone == 1
 
             DialogueBodyLabel.VisibleCharacters++;
-            GD.Print(DialogueBodyLabel.VisibleCharacters);
         }
     }
 
@@ -64,7 +63,6 @@ public partial class DialogueBox : Control
             {
                 if (DialogueBodyLabel.VisibleRatio < 1)
                 {
-                    GD.Print("L + ratio = ", DialogueBodyLabel.VisibleRatio);
                     DialogueBodyLabel.VisibleRatio = 1;
                 }
                 else
@@ -78,7 +76,6 @@ public partial class DialogueBox : Control
 
     public void OpenDialogue(DialogueReel reel)
     {
-        GD.Print(reel.Frames.Count());
         dialougeIsDone = false;
         if (!_dialoguePlayer.StartDialogue(reel, this))
         {
@@ -109,7 +106,6 @@ public partial class DialogueBox : Control
     {
         if (_dialoguePlayer.AdvanceText())
         {
-            GD.Print("Advanced. CurrentFrame = ", _dialoguePlayer.CurrentFrame);
             UpdateDialogueBox();
             _timer = 0;
         }
@@ -134,8 +130,6 @@ public partial class DialogueBox : Control
     private void SetPortrait()
     {
         //sets the portriat of the speaker from the current Dialogue frame
-        GD.Print(_dialoguePlayer.GetPath());
-        GD.Print(_dialoguePlayer.CurrentFrame);
         var portrait = _dialoguePlayer.CurrentFrame.Portrait;
         if (portrait?.Length > 0)
         {


### PR DESCRIPTION
Cleans up high velocity print statements that run nearly every frame. This doesn't remove all the print statements, just the ones that clutter up the debug console.

---

This pull request removes a large number of debug `GD.Print` statements from various files across the codebase. These print statements were primarily used for debugging and logging during development and are no longer needed. Removing them helps clean up the code and reduces unnecessary console output during gameplay.

The most important changes are:

### Boss and Enemy Logic Cleanup

* Removed debug print statements from boss state classes such as `Drill`, `FileCypher`, and `Siracus` (including attack, critter, tail, shotgun, and slash states), as well as from the `BatSwooping` enemy logic. This makes the code cleaner and prevents clutter in the debug console. [[1]](diffhunk://#diff-03988fbcd3d2883f4bac0ef43c4136e187f606885d76353c4381e02a69e07de1L181-L182) [[2]](diffhunk://#diff-fb8fd2f25ccab53246d0b171f296bb88632732824d715539790b74da4b9348c5L23-L24) [[3]](diffhunk://#diff-a563e1449de8875596dcaf6ff5aad6c455d6e59ea9e849285043c44110e44cd7L75-L76) [[4]](diffhunk://#diff-1a57bfbe88b4dadd2849496a699f4d45f53a0e7b66b397aeee9a4abd8109cf5bL27-L28) [[5]](diffhunk://#diff-969cbfbc38729a78e8f15734d8ea9954779855b632078528a3ed2576986b3f43L34-L35) [[6]](diffhunk://#diff-b5b3adcbccb97679704c3649928f0791f0b49e6a7d97c2b484d5af97d3f892daL127) [[7]](diffhunk://#diff-b5b3adcbccb97679704c3649928f0791f0b49e6a7d97c2b484d5af97d3f892daL245) [[8]](diffhunk://#diff-55487c5cd65ec17d757c5fb1bbe036831037ea6af0cbcf160a1d43b7e08e5772L64-L65) [[9]](diffhunk://#diff-ac6c859f728e7f3097c0aeb1b0de2c81ba7944eeea819b7fbe7d89fd2969d11dL81-L82) [[10]](diffhunk://#diff-9888c21b92e8c81c8b13ca438a068258904c27c070338d3515846a9ff09d8c14L34-L35) [[11]](diffhunk://#diff-9888c21b92e8c81c8b13ca438a068258904c27c070338d3515846a9ff09d8c14L52-L53) [[12]](diffhunk://#diff-9888c21b92e8c81c8b13ca438a068258904c27c070338d3515846a9ff09d8c14L76-L85) [[13]](diffhunk://#diff-a48f097e78ec73a523865c806092543226229669eb99cea4a38a368e173a344dL43-L44) [[14]](diffhunk://#diff-04954dc9a56ed90dce91895e1f7bab9722bae993a25357a0c1db4b5affd37441L16-L17) [[15]](diffhunk://#diff-d9eddd7d988b0a6084f96c4b63361a2e69b204a0f20918227f0e1b5c852929b4L44-L45) [[16]](diffhunk://#diff-d9eddd7d988b0a6084f96c4b63361a2e69b204a0f20918227f0e1b5c852929b4L123-L124) [[17]](diffhunk://#diff-4fe6988f8e85b3fc3373d3a8ff8f35c0974f1ef71efe4e53c28589d62c9d52c3L62-L63)

### Dialogue System Cleanup

* Removed debug print statements from dialogue-related files such as `DialoguePlayer.cs` and `DialogueBox.cs`, including dialogue frame loading, advancing, and UI updates. This results in a cleaner output during cutscenes and dialogue sequences. [[1]](diffhunk://#diff-94fd966b46a56d2cf15cc95aac468b1b4dc04701d467b672a0f08f626d91ff89L67) [[2]](diffhunk://#diff-94fd966b46a56d2cf15cc95aac468b1b4dc04701d467b672a0f08f626d91ff89L152-L163) [[3]](diffhunk://#diff-2f52afdeef76b25aa3ddd4ddb66e5265d272d6a942b938abdfa64dee0ebd044eL51) [[4]](diffhunk://#diff-2f52afdeef76b25aa3ddd4ddb66e5265d272d6a942b938abdfa64dee0ebd044eL67) [[5]](diffhunk://#diff-2f52afdeef76b25aa3ddd4ddb66e5265d272d6a942b938abdfa64dee0ebd044eL81) [[6]](diffhunk://#diff-2f52afdeef76b25aa3ddd4ddb66e5265d272d6a942b938abdfa64dee0ebd044eL112) [[7]](diffhunk://#diff-2f52afdeef76b25aa3ddd4ddb66e5265d272d6a942b938abdfa64dee0ebd044eL137-L138)

### Character State Logic

* Removed print statements from `CharacterMergeHoldState.cs` that logged healing and health pool information, further reducing debug noise during gameplay.

Overall, these changes focus on code cleanliness and maintainability by eliminating unnecessary debug output.