### PR TITLE
fix: Prevent healing if player has died

### DIFF
--- a/CrossedDimensions.Tests/Integration/HealingPoolIntegrationTest.cs
+++ b/CrossedDimensions.Tests/Integration/HealingPoolIntegrationTest.cs
@@ -2,6 +2,7 @@ using System;
 using CrossedDimensions.BoundingBoxes;
 using CrossedDimensions.Components;
 using CrossedDimensions.Characters;
+using CrossedDimensions.States.Characters;
 using Godot;
 
 namespace CrossedDimensions.Tests.Integration;
@@ -158,5 +159,21 @@ public class HealingPoolIntegrationTest : IDisposable
         setup.Hurtbox.Hit(setup.Hitbox);
 
         setup.OriginalCloneable.HealingPool.ShouldBe(0f);
+    }
+
+    [Fact]
+    public void CharacterMergeHoldState_Process_WhenPlayerDies_ShouldStopHealing()
+    {
+        var setup = new CloneAttacksEnemySetup(_godot, _scene);
+        var mergeHoldState = setup.Original.MovementStateMachine
+            .GetNode<CharacterMergeHoldState>("Merge Hold State");
+        setup.Original.MovementStateMachine.ChangeState(mergeHoldState);
+
+        setup.Original.Health.CurrentHealth = 0;
+
+        mergeHoldState.Process(0);
+
+        // state machine should not be the merge hold state
+        setup.Original.MovementStateMachine.CurrentState.ShouldNotBe(mergeHoldState);
     }
 }

--- a/States/Characters/CharacterMergeHoldState.cs
+++ b/States/Characters/CharacterMergeHoldState.cs
@@ -26,6 +26,15 @@ public sealed partial class CharacterMergeHoldState : CharacterState
 
     public override State Process(double delta)
     {
+        // stop healing if the character died mid-merge
+        // death disables input but does not halt this state, so without this
+        // guard the heal loop would revive the character while the death
+        // sequence is already in progress
+        if (!CharacterContext.Health.IsAlive)
+        {
+            return IdleState;
+        }
+
         var cloneable = CharacterContext.Cloneable;
         if (cloneable.HealingPool > 0)
         {


### PR DESCRIPTION
Adds a guard to return to idle state if player dies while healing. There is already a check to guard player from healing after dying, but there was no guard to stop healing if the player dies mid-heal. Closes #191 

---

This pull request adds a safeguard to the character merge healing logic to prevent a dead character from being healed or revived during the death sequence. It also introduces a new integration test to verify this behavior.

**Bug fix: Prevent healing after death during merge**

* [`States/Characters/CharacterMergeHoldState.cs`](diffhunk://#diff-f0a97f6ef1aa66dc9c0220b69c4a65d626bd4003370ccba9e62ee8b260cf3e3eR29-R37): Added a check in the `Process` method to immediately exit the merge hold state if the character is dead, preventing the healing loop from reviving the character during the death sequence.

**Testing:**

* [`CrossedDimensions.Tests/Integration/HealingPoolIntegrationTest.cs`](diffhunk://#diff-3f99afa749d15f89a6f2c06e24bbf579ebacdeb7d3e0baea0d4d44c7cf610171R163-R178): Added a new test `CharacterMergeHoldState_Process_WhenPlayerDies_ShouldStopHealing` to ensure that the state machine exits the merge hold state when the character dies, and that healing does not occur.
* Added necessary using directive for `CrossedDimensions.States.Characters` to support the new test.