### PR TITLE
feature: Add splitting iframes

### DIFF
--- a/BoundingBoxes/Hurtbox.cs
+++ b/BoundingBoxes/Hurtbox.cs
@@ -52,6 +52,32 @@ public partial class Hurtbox : BoundingBox
     [Signal]
     public delegate void HurtboxHitEventHandler(Hitbox hitbox, float damage);
 
+    public override void _Ready()
+    {
+        var invuln = OwnerCharacter?.Invulnerability;
+        if (invuln is not null)
+        {
+            invuln.InvulnerabilityStarted += OnInvulnerabilityStarted;
+            invuln.InvulnerabilityEnded += OnInvulnerabilityEnded;
+        }
+
+        base._Ready();
+    }
+
+    private void OnInvulnerabilityStarted()
+    {
+        // stop detecting hitboxes while invulnerable. Deferred because this
+        // may fire from within a physics callback (e.g. a state's Enter).
+        SetDeferred(Area2D.PropertyName.Monitorable, false);
+    }
+
+    private void OnInvulnerabilityEnded()
+    {
+        // re-enabling makes overlapping hitboxes re-emit AreaEntered, so a hit
+        // that landed during invulnerability is re-evaluated once it ends.
+        SetDeferred(Area2D.PropertyName.Monitorable, true);
+    }
+
     /// <summary>
     /// Determines if a hit from the given hitbox should be ignored,
     /// for example if the hitbox belongs to the same character
@@ -109,6 +135,15 @@ public partial class Hurtbox : BoundingBox
     /// </summary>
     public bool Hit(Hitbox hitbox)
     {
+        // ignore hits while the owner is invulnerable (e.g. during a split).
+        // The hurtbox also stops being monitorable while invulnerable (see
+        // _Ready), so a hit overlapping during this window is re-evaluated
+        // once invulnerability ends and the hurtbox is re-enabled.
+        if (OwnerCharacter?.IsInvulnerable == true)
+        {
+            return false;
+        }
+
         // if an iframe timer is provided and running, ignore the hit
         if (IFrameTimer is not null && !IFrameTimer.IsStopped())
         {

--- a/Characters/BaseCharacter.tscn
+++ b/Characters/BaseCharacter.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=44 format=3 uid="uid://dbrsyvtefql5h"]
+[gd_scene load_steps=45 format=3 uid="uid://dbrsyvtefql5h"]
 
 [ext_resource type="Script" uid="uid://t5xa8pqv2chw" path="res://Characters/Character.cs" id="1_xloa1"]
 [ext_resource type="Script" uid="uid://dqpkcaajawmmr" path="res://Characters/CloneableComponent.cs" id="2_peemv"]
@@ -33,6 +33,7 @@
 [ext_resource type="Script" uid="uid://g3ryl11hyvb5" path="res://Characters/MergeEffectSource.cs" id="31_mergeeffect"]
 [ext_resource type="AnimationLibrary" uid="uid://0t1q0vcx0oho" path="res://Assets/Animations/CharacterAnimationLibrary.tres" id="32_hchpp"]
 [ext_resource type="Texture2D" uid="uid://coynjpceuh1jk" path="res://Assets/Textures/circle-16.png" id="34_yex2g"]
+[ext_resource type="Script" uid="uid://cr6ox22ske7xr" path="res://Components/InvulnerabilityComponent.cs" id="35_invuln"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_xloa1"]
 size = Vector2(12, 22)
@@ -94,7 +95,7 @@ scale_max = 0.25
 scale_curve = SubResource("CurveTexture_jm4o1")
 turbulence_enabled = true
 
-[node name="Character" type="CharacterBody2D" node_paths=PackedStringArray("SpriteAnchor", "Controller", "MovementStateMachine", "Inventory", "Freezable", "Health", "Cloneable")]
+[node name="Character" type="CharacterBody2D" node_paths=PackedStringArray("SpriteAnchor", "Controller", "MovementStateMachine", "Inventory", "Freezable", "Health", "Invulnerability", "Cloneable")]
 collision_layer = 2
 collision_mask = 29
 script = ExtResource("1_xloa1")
@@ -104,6 +105,7 @@ MovementStateMachine = NodePath("MovementStateMachine")
 Inventory = NodePath("InventoryComponent")
 Freezable = NodePath("FreezableComponent")
 Health = NodePath("HealthComponent")
+Invulnerability = NodePath("InvulnerabilityComponent")
 Cloneable = NodePath("CloneableComponent")
 
 [node name="ControllerComponent" type="Node2D" parent="."]
@@ -220,6 +222,9 @@ script = ExtResource("18_noclip")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, -4)
 shape = SubResource("RectangleShape2D_xloa1")
+
+[node name="InvulnerabilityComponent" type="Node" parent="."]
+script = ExtResource("35_invuln")
 
 [node name="HealthComponent" type="Node" parent="."]
 script = ExtResource("11_fgiha")

--- a/Characters/Character.cs
+++ b/Characters/Character.cs
@@ -96,6 +96,13 @@ public partial class Character : CharacterBody2D
     public Components.HealthComponent Health { get; set; }
 
     /// <summary>
+    /// The invulnerability component that lets this character temporarily
+    /// ignore incoming hits. If null, this character is never invulnerable.
+    /// </summary>
+    [Export]
+    public Components.InvulnerabilityComponent Invulnerability { get; set; }
+
+    /// <summary>
     /// The state machine that controls the brain (AI or player) of the character.
     /// </summary>
     [Export]
@@ -125,6 +132,8 @@ public partial class Character : CharacterBody2D
     public Vector2 VelocityFromExternalForces { get; set; } = Vector2.Zero;
 
     public bool IsFrozen => Freezable?.IsFrozen ?? false;
+
+    public bool IsInvulnerable => Invulnerability?.IsInvulnerable ?? false;
 
     public override void _Ready()
     {

--- a/Components/InvulnerabilityComponent.cs
+++ b/Components/InvulnerabilityComponent.cs
@@ -1,0 +1,125 @@
+using Godot;
+
+namespace CrossedDimensions.Components;
+
+/// <summary>
+/// Component that grants a character temporary invulnerability, causing its
+/// hurtbox to ignore incoming hits. Supports two modes that can overlap:
+/// open-ended holds via <see cref="Acquire"/>/<see cref="Release"/> (e.g. for
+/// the duration of a state, such as splitting) and timed grants via
+/// <see cref="Grant"/> (e.g. post-hit invulnerability frames).
+/// </summary>
+[GlobalClass]
+public partial class InvulnerabilityComponent : Node
+{
+    /// <summary>
+    /// Emitted when the character becomes invulnerable, i.e. when the first
+    /// source is acquired or granted while previously vulnerable.
+    /// </summary>
+    [Signal]
+    public delegate void InvulnerabilityStartedEventHandler();
+
+    /// <summary>
+    /// Emitted when the character becomes vulnerable again, i.e. when the last
+    /// source is released or the timed grant expires.
+    /// </summary>
+    [Signal]
+    public delegate void InvulnerabilityEndedEventHandler();
+
+    /// <summary>
+    /// The number of open-ended sources currently holding invulnerability.
+    /// Counted so overlapping sources (e.g. a split window and a post-hit
+    /// grant) do not clear one another; invulnerability stays active while any
+    /// source remains.
+    /// </summary>
+    private int _sources;
+
+    /// <summary>
+    /// The remaining time on the current timed grant, in seconds.
+    /// </summary>
+    private float _timeLeft;
+
+    /// <returns>
+    /// <c>true</c> while any source or timed grant is active; otherwise,
+    /// <c>false</c>.
+    /// </returns>
+    public bool IsInvulnerable => _sources > 0 || _timeLeft > 0f;
+
+    public override void _Ready()
+    {
+        SetProcess(false);
+    }
+
+    /// <summary>
+    /// Acquires an open-ended invulnerability hold that lasts until a matching
+    /// <see cref="Release"/>. Use for state-bound invulnerability such as the
+    /// split state.
+    /// </summary>
+    public void Acquire()
+    {
+        bool wasInvulnerable = IsInvulnerable;
+        _sources++;
+        if (!wasInvulnerable)
+        {
+            EmitSignal(SignalName.InvulnerabilityStarted);
+        }
+    }
+
+    /// <summary>
+    /// Releases a hold previously taken with <see cref="Acquire"/>. Has no
+    /// effect if there are no outstanding holds.
+    /// </summary>
+    public void Release()
+    {
+        if (_sources <= 0)
+        {
+            return;
+        }
+
+        _sources--;
+        if (!IsInvulnerable)
+        {
+            EmitSignal(SignalName.InvulnerabilityEnded);
+        }
+    }
+
+    /// <summary>
+    /// Grants timed invulnerability for the given duration, in seconds. If a
+    /// longer grant is already active, the longer duration is kept. Use for
+    /// fixed-length invulnerability such as post-hit frames.
+    /// </summary>
+    public void Grant(float duration)
+    {
+        if (duration <= 0f)
+        {
+            return;
+        }
+
+        bool wasInvulnerable = IsInvulnerable;
+        _timeLeft = Mathf.Max(_timeLeft, duration);
+        SetProcess(true);
+        if (!wasInvulnerable)
+        {
+            EmitSignal(SignalName.InvulnerabilityStarted);
+        }
+    }
+
+    public override void _Process(double delta)
+    {
+        if (_timeLeft <= 0f)
+        {
+            SetProcess(false);
+            return;
+        }
+
+        _timeLeft = Mathf.Max(0f, _timeLeft - (float)delta);
+        if (_timeLeft <= 0f)
+        {
+            SetProcess(false);
+            if (!IsInvulnerable)
+            {
+                EmitSignal(SignalName.InvulnerabilityEnded);
+            }
+        }
+    }
+}

--- a/Components/InvulnerabilityComponent.cs.uid
+++ b/Components/InvulnerabilityComponent.cs.uid
@@ -1,0 +1,1 @@
+uid://cr6ox22ske7xr

--- a/CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs
+++ b/CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs
@@ -255,4 +255,70 @@ public class HurtboxTest(GodotHeadlessFixedFpsFixture godot)
         Assert.False(hitEmitted);
 
     }
+
+    [Fact]
+    public void Hurtbox_Hit_IgnoredWhileOwnerInvulnerable_RegistersAfter()
+    {
+        var hitbox = new Hitbox();
+        var hurtbox = new Hurtbox();
+
+        var damage = new DamageComponent() { DamageAmount = 10, KnockbackMultiplier = 1f };
+        hitbox.DamageComponent = damage;
+
+        var health = new HealthComponent() { MaxHealth = 100 };
+        health.CurrentHealth = 100;
+        hurtbox.HealthComponent = health;
+
+        var owner = new Character();
+        var invuln = new InvulnerabilityComponent();
+        owner.Invulnerability = invuln;
+        hurtbox.OwnerCharacter = owner;
+
+        godot.Tree.Root.AddChild(owner);
+        godot.Tree.Root.AddChild(invuln);
+        godot.Tree.Root.AddChild(hitbox);
+        godot.Tree.Root.AddChild(hurtbox);
+        godot.Tree.Root.AddChild(health);
+        godot.Tree.Root.AddChild(damage);
+
+        hitbox.GlobalPosition = new Vector2(0, 0);
+        hurtbox.GlobalPosition = new Vector2(10, 0);
+
+        invuln.Acquire();
+
+        // hit ignored while invulnerable: no damage, not registered
+        hurtbox.Hit(hitbox).ShouldBeFalse();
+        health.CurrentHealth.ShouldBe(100);
+
+        // once invulnerability ends, the same hit registers
+        invuln.Release();
+        hurtbox.Hit(hitbox).ShouldBeTrue();
+        health.CurrentHealth.ShouldBe(90);
+    }
+
+    [Fact]
+    public void Hurtbox_StopsBeingMonitorable_WhileOwnerInvulnerable()
+    {
+        var owner = new Character();
+        var invuln = new InvulnerabilityComponent();
+        owner.Invulnerability = invuln;
+
+        var hurtbox = new Hurtbox();
+        hurtbox.OwnerCharacter = owner;
+
+        godot.Tree.Root.AddChild(owner);
+        godot.Tree.Root.AddChild(invuln);
+        // adding the hurtbox runs _Ready, which subscribes to invuln signals
+        godot.Tree.Root.AddChild(hurtbox);
+
+        hurtbox.Monitorable.ShouldBeTrue();
+
+        invuln.Acquire();
+        godot.GodotInstance.Iteration(1); // flush the deferred Monitorable set
+        hurtbox.Monitorable.ShouldBeFalse();
+
+        invuln.Release();
+        godot.GodotInstance.Iteration(1);
+        hurtbox.Monitorable.ShouldBeTrue();
+    }
 }

--- a/CrossedDimensions.Tests/Components/InvulnerabilityComponentTest.cs
+++ b/CrossedDimensions.Tests/Components/InvulnerabilityComponentTest.cs
@@ -1,0 +1,114 @@
+using Godot;
+using twodog.xunit;
+using Xunit;
+using CrossedDimensions.Components;
+using Shouldly;
+
+namespace CrossedDimensions.Tests.Components;
+
+[Collection("GodotHeadless")]
+public class InvulnerabilityComponentTest(GodotHeadlessFixedFpsFixture godot)
+{
+    [Fact]
+    public void IsInvulnerable_WhenCreated_IsFalse()
+    {
+        var invuln = new InvulnerabilityComponent();
+        godot.Tree.Root.AddChild(invuln);
+
+        invuln.IsInvulnerable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Acquire_MakesInvulnerable_AndReleaseClearsIt()
+    {
+        var invuln = new InvulnerabilityComponent();
+        godot.Tree.Root.AddChild(invuln);
+
+        invuln.Acquire();
+        invuln.IsInvulnerable.ShouldBeTrue();
+
+        invuln.Release();
+        invuln.IsInvulnerable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void OverlappingHolds_StayInvulnerableUntilAllReleased()
+    {
+        var invuln = new InvulnerabilityComponent();
+        godot.Tree.Root.AddChild(invuln);
+
+        invuln.Acquire();
+        invuln.Acquire();
+
+        invuln.Release();
+        // one source remains, so still invulnerable
+        invuln.IsInvulnerable.ShouldBeTrue();
+
+        invuln.Release();
+        invuln.IsInvulnerable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Release_WithNoHolds_DoesNothing()
+    {
+        var invuln = new InvulnerabilityComponent();
+        godot.Tree.Root.AddChild(invuln);
+
+        invuln.Release();
+        invuln.IsInvulnerable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Acquire_EmitsStartedOnlyOnTransitionToInvulnerable()
+    {
+        var invuln = new InvulnerabilityComponent();
+        godot.Tree.Root.AddChild(invuln);
+
+        int started = 0;
+        invuln.InvulnerabilityStarted += () => started++;
+
+        invuln.Acquire();
+        invuln.Acquire();
+
+        started.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Release_EmitsEndedOnlyWhenLastHoldCleared()
+    {
+        var invuln = new InvulnerabilityComponent();
+        godot.Tree.Root.AddChild(invuln);
+
+        int ended = 0;
+        invuln.InvulnerabilityEnded += () => ended++;
+
+        invuln.Acquire();
+        invuln.Acquire();
+
+        invuln.Release();
+        ended.ShouldBe(0);
+
+        invuln.Release();
+        ended.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Grant_MakesInvulnerableImmediately()
+    {
+        var invuln = new InvulnerabilityComponent();
+        godot.Tree.Root.AddChild(invuln);
+
+        invuln.Grant(0.5f);
+        invuln.IsInvulnerable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Grant_WithNonPositiveDuration_DoesNothing()
+    {
+        var invuln = new InvulnerabilityComponent();
+        godot.Tree.Root.AddChild(invuln);
+
+        invuln.Grant(0f);
+        invuln.IsInvulnerable.ShouldBeFalse();
+    }
+}

--- a/CrossedDimensions.Tests/Integration/CloneableComponentIntegrationTest.cs
+++ b/CrossedDimensions.Tests/Integration/CloneableComponentIntegrationTest.cs
@@ -294,6 +294,34 @@ public class CloneableComponentIntegrationTest : IDisposable
     }
 
     [Fact]
+    public void Character_ShouldHaveInvulnerabilityComponentWired()
+    {
+        _character.Invulnerability.ShouldNotBeNull();
+        _character.IsInvulnerable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CloneableComponent_Split_ShouldMakeCloneInvulnerable()
+    {
+        // the clone starts in the split state, so it is invulnerable too
+        var clone = _character.Cloneable.Split();
+
+        clone.ShouldNotBeNull();
+        clone.IsInvulnerable.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Character_WhileInSplitState_ShouldBeInvulnerableThenRecover()
+    {
+        _character.MovementStateMachine.ChangeState("Split State");
+        _character.IsInvulnerable.ShouldBeTrue();
+
+        // leaving the split state releases the invulnerability hold
+        _character.MovementStateMachine.ChangeState("Idle State");
+        _character.IsInvulnerable.ShouldBeFalse();
+    }
+
+    [Fact]
     public void CloneableComponent_HealingPool_ShouldInitializeToZero()
     {
         _character.Cloneable.HealingPool.ShouldBe(0f);

--- a/States/Characters/CharacterSplitState.cs
+++ b/States/Characters/CharacterSplitState.cs
@@ -41,6 +41,13 @@ public sealed partial class CharacterSplitState : CharacterState
             return IdleState;
         }
 
+        // hold invulnerability for the lifetime of this state. Released via
+        // the Exited signal instead of an Exit() override, because overriding
+        // the base State.Exit collides with the Exited signal in Godot's
+        // source generator and crashes on scene use.
+        CharacterContext.Invulnerability?.Acquire();
+        Exited += OnExitedReleaseInvulnerability;
+
         _inputDirection = CharacterContext.Controller
             .MovementInput
             .Normalized();
@@ -54,6 +61,12 @@ public sealed partial class CharacterSplitState : CharacterState
         }
 
         return base.Enter(previousState);
+    }
+
+    private void OnExitedReleaseInvulnerability(State nextState)
+    {
+        Exited -= OnExitedReleaseInvulnerability;
+        CharacterContext.Invulnerability?.Release();
     }
 
     public override State Process(double delta) => base.Process(delta);


### PR DESCRIPTION
Adds splitting iframes with a new component that maintains a counter for different invuln sources.

---

This pull request introduces a modular invulnerability system for characters, allowing them to temporarily ignore incoming hits. The new `InvulnerabilityComponent` supports both open-ended and timed invulnerability, integrates with the character and hurtbox logic, and is thoroughly tested. Key changes include the addition of the component, updates to the character and hurtbox classes, scene wiring, and comprehensive unit and integration tests.

### Invulnerability System Implementation

* Added `InvulnerabilityComponent`, which allows characters to become invulnerable either for a fixed duration or while a state is active. It emits signals when invulnerability starts or ends and supports overlapping sources. (`Components/InvulnerabilityComponent.cs`, `Components/InvulnerabilityComponent.cs.uid`) [[1]](diffhunk://#diff-5f7e052be997ae266ae982d2d09abe1499db4f49f81965c8a554c207ed786324R1-R125) [[2]](diffhunk://#diff-83a23c2f55902b9a991eea499a8e8aac6a52b16c4d4821d5f9a3c55f4d889604R1)
* Updated `Character` to expose the `Invulnerability` property and `IsInvulnerable` status, and wired the component in the scene file. (`Characters/Character.cs`, `Characters/BaseCharacter.tscn`) [[1]](diffhunk://#diff-005ddbe6e2c959637fbf531308c9dab94831cf0547b523523a1d0ef398362035R98-R104) [[2]](diffhunk://#diff-005ddbe6e2c959637fbf531308c9dab94831cf0547b523523a1d0ef398362035R136-R137) [[3]](diffhunk://#diff-a5e24688d73f8524b6b274ab022c790ed05e49f398a3d78bea2692f869e9a365R36) [[4]](diffhunk://#diff-a5e24688d73f8524b6b274ab022c790ed05e49f398a3d78bea2692f869e9a365L97-R98) [[5]](diffhunk://#diff-a5e24688d73f8524b6b274ab022c790ed05e49f398a3d78bea2692f869e9a365R108) [[6]](diffhunk://#diff-a5e24688d73f8524b6b274ab022c790ed05e49f398a3d78bea2692f869e9a365R226-R228)

### Hurtbox Integration

* Modified `Hurtbox` so it ignores hits while its owner is invulnerable and disables hit detection when invulnerability is active. This is managed via signals from the `InvulnerabilityComponent`. (`BoundingBoxes/Hurtbox.cs`) [[1]](diffhunk://#diff-cb1a975ef3d0bf4d470c92eea6dcd05c58144a358532bc1530f5af9c01a0e70eR55-R80) [[2]](diffhunk://#diff-cb1a975ef3d0bf4d470c92eea6dcd05c58144a358532bc1530f5af9c01a0e70eR138-R146)

### State Machine Support

* Updated the character split state to acquire invulnerability for the duration of the state and release it when exiting, ensuring correct invulnerability transitions during gameplay. (`States/Characters/CharacterSplitState.cs`) [[1]](diffhunk://#diff-f79c31c18021eea3409c9cbc59b2b35f9e5bc52157f7d438351ed991be4416bfR44-R50) [[2]](diffhunk://#diff-f79c31c18021eea3409c9cbc59b2b35f9e5bc52157f7d438351ed991be4416bfR66-R71)

### Testing

* Added comprehensive unit tests for the `InvulnerabilityComponent`, including overlapping holds and timed grants. (`CrossedDimensions.Tests/Components/InvulnerabilityComponentTest.cs`)
* Extended hurtbox tests to verify hit ignoring and monitorable toggling during invulnerability. (`CrossedDimensions.Tests/BoundingBoxes/HurtboxTest.cs`)
* Added integration tests confirming the component is correctly wired, and invulnerability is handled during the split state and for clones. (`CrossedDimensions.Tests/Integration/CloneableComponentIntegrationTest.cs`)